### PR TITLE
Tidyup2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,158 @@
+# Original makefile from https://github.com/martinthomson/i-d-template
+
+# The following tools are used by this file.
+# All are assumed to be on the path, but you can override these
+# in the environment, or command line.
+
+# Mandatory:
+#   https://pypi.python.org/pypi/xml2rfc
+xml2rfc ?= xml2rfc
+
+# If you are using markdown files:
+#   https://github.com/cabo/kramdown-rfc2629
+kramdown-rfc2629 ?= kramdown-rfc2629
+
+# If you are using outline files:
+#   https://github.com/Juniper/libslax/tree/master/doc/oxtradoc
+oxtradoc ?= oxtradoc.in
+
+# For sanity checkout your draft:
+#   https://tools.ietf.org/tools/idnits/
+idnits ?= idnits
+
+# For diff:
+#   https://tools.ietf.org/tools/rfcdiff/
+rfcdiff ?= rfcdiff --browse
+
+# For generating PDF:
+#   https://www.gnu.org/software/enscript/
+enscript ?= enscript
+#   http://www.ghostscript.com/
+ps2pdf ?= ps2pdf 
+
+
+## Work out what to build
+
+draft := $(basename $(lastword $(sort $(wildcard draft-*.xml)) $(sort $(wildcard draft-*.org)) $(sort $(wildcard draft-*.md))))
+
+ifeq (,$(draft))
+$(warning No file named draft-*.md or draft-*.xml or draft-*.org)
+$(error Read README.md for setup instructions)
+endif
+
+draft_type := $(suffix $(firstword $(wildcard $(draft).md $(draft).org $(draft).xml)))
+
+## Targets
+default:
+	@echo 
+	@echo "Useful targets:"
+	@echo "  txt: The Text version of the draft"
+	@echo "  commit: Creates README.md, commits (ci) and pushes the changes to git" 
+	@echo "  tag: Lists current tags, gets  anew one, commits and pushed to git"
+	@echo "  diff: Unsurprisingly, the diff..."
+	@echo
+
+
+.PHONY: latest txt html pdf submit diff clean update ghpages
+
+latest: txt html
+txt: $(draft).txt
+html: $(draft).html
+pdf: $(draft).pdf
+
+
+idnits: $(draft).txt
+	$(idnits) $<
+
+
+clean:
+	-rm -f $(draft).{txt,html,pdf} index.html
+	-rm -f $(draft)-[0-9][0-9].{xml,md,org,txt,html,pdf}
+	-rm -f *.diff.html
+ifneq (.xml,$(draft_type))
+	-rm -f $(draft).xml
+endif
+
+## diff
+
+diff:
+	git diff $(draft).xml
+
+
+commit: $(draft).txt README.md
+	@echo "Making README.md and committing and pushing to github. Run 'make tag' to add and push a tag."
+	@echo '**Important:** Read CONTRIBUTING.md before submitting feedback or contributing' > README.md
+	@echo \`\`\` >> README.md
+	@cat $(draft).txt >> README.md
+	@echo \`\`\` >> README.md
+	read -p "Commit message: " msg; \
+	git commit -a -m "$$msg";
+	@git push
+
+tag:
+	@echo "Current tags:"
+	git tag
+	@echo
+	@read -p "Tag message (e.g: Version-00): " tag; \
+	git tag -a $$tag -m $$tag
+	@git push --tags
+
+## Recipes
+
+.INTERMEDIATE: $(draft).xml
+%.xml: %.md
+	$(kramdown-rfc2629) $< > $@
+
+%.xml: %.org
+	$(oxtradoc) -m outline-to-xml -n "$@" $< > $@
+
+%.txt: %.xml
+	$(xml2rfc) $< -o $@ --text
+
+%.html: %.xml
+	$(xml2rfc) $< -o $@ --html
+
+%.pdf: %.txt
+	$(enscript) --margins 76::76: -B -q -p - $^ | $(ps2pdf) - $@
+
+
+## Update the gh-pages branch with useful files
+
+
+# Only run upload if we are local or on the master branch
+IS_LOCAL := $(if $(TRAVIS),,true)
+ifeq (master,$(TRAVIS_BRANCH))
+IS_MASTER := $(findstring false,$(TRAVIS_PULL_REQUEST))
+else
+IS_MASTER :=
+endif
+
+index.html: $(draft).html
+	cp $< $@
+
+ghpages: index.html $(draft).txt
+ifneq (,$(or $(IS_LOCAL),$(IS_MASTER)))
+	mkdir $(GHPAGES_TMP)
+	cp -f $^ $(GHPAGES_TMP)
+	git clean -qfdX
+ifeq (true,$(TRAVIS))
+	git config user.email "ci-bot@example.com"
+	git config user.name "Travis CI Bot"
+	git checkout -q --orphan gh-pages
+	git rm -qr --cached .
+	git clean -qfd
+	git pull -qf origin gh-pages --depth=5
+else
+	git checkout gh-pages
+	git pull
+endif
+	mv -f $(GHPAGES_TMP)/* $(CURDIR)
+	git add $^
+	if test `git status -s | wc -l` -gt 0; then git commit -m "Script updating gh-pages."; fi
+ifneq (,$(GH_TOKEN))
+	@echo git push https://github.com/$(TRAVIS_REPO_SLUG).git gh-pages
+	@git push https://$(GH_TOKEN)@github.com/$(TRAVIS_REPO_SLUG).git gh-pages
+endif
+	-git checkout -qf "$(GIT_ORIG)"
+	-rm -rf $(GHPAGES_TMP)
+endif

--- a/draft-sury-dnsop-deprecate-obsolete-resource-records.txt
+++ b/draft-sury-dnsop-deprecate-obsolete-resource-records.txt
@@ -4,9 +4,9 @@
 
 dnsop                                                            O. Sury
 Internet-Draft                               Internet Systems Consortium
-Updates: 1035,3597,4035 (if approved)                     March 26, 2018
+Updates: 1035,3597,4035 (if approved)                   October 14, 2020
 Intended status: Standards Track
-Expires: September 27, 2018
+Expires: April 17, 2021
 
 
             Deprecating obsolete DNS Resource Records Types
@@ -15,7 +15,7 @@ Expires: September 27, 2018
 Abstract
 
    This document deprecates Resource Records (RR) Types that are either
-   not being used for anything meaningful or were been already made
+   not being used for anything meaningful or have already been rendered
    obsolete by other RFCs.  This document updates [RFC1035], [RFC1035],
    [RFC4034].
 
@@ -34,11 +34,11 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on September 27, 2018.
+   This Internet-Draft will expire on April 17, 2021.
 
 Copyright Notice
 
-   Copyright (c) 2018 IETF Trust and the persons identified as the
+   Copyright (c) 2020 IETF Trust and the persons identified as the
    document authors.  All rights reserved.
 
    This document is subject to BCP 78 and the IETF Trust's Legal
@@ -53,66 +53,71 @@ Copyright Notice
 
 
 
-Sury                   Expires September 27, 2018               [Page 1]
+Sury                     Expires April 17, 2021                 [Page 1]
 
-Internet-Draft        Deprecating old mail RRTYPES            March 2018
+Internet-Draft        Deprecating old mail RRTYPES          October 2020
 
 
 Table of Contents
 
    1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   2
-   2.  Deprecating MD, MF, MB, MG, MR, MINFO, MAILA, and MAILBRR
+   2.  Deprecating MD, MF, MB, MG, MR, MINFO, MAILA, and MAILB RR
        Types . . . . . . . . . . . . . . . . . . . . . . . . . . . .   2
-   3.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   2
+   3.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   3
    4.  Implementation Considerations . . . . . . . . . . . . . . . .   3
-   5.  Security Considerations . . . . . . . . . . . . . . . . . . .   3
+   5.  Security Considerations . . . . . . . . . . . . . . . . . . .   4
    6.  Operational Considerations  . . . . . . . . . . . . . . . . .   4
    7.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .   4
    8.  References  . . . . . . . . . . . . . . . . . . . . . . . . .   4
      8.1.  Normative References  . . . . . . . . . . . . . . . . . .   4
      8.2.  Informative References  . . . . . . . . . . . . . . . . .   4
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .   4
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .   5
 
 1.  Introduction
 
-   The [RFC1035] defines couple of old Resource Record (RR) Types that
-   are not being used, and they are not in use and should have been
-   obsoleted years ago.  Some of these RR Types are even causing
-   operational problems between implementations that support them and
-   that don't supported them due DNS compression on the wire, or .  This
-   document deprecates such records to allow the implementations to drop
-   the specific support for such records.
+   [RFC1035] and other documents defined some Resource Record (RR) Types
+   that are no longer in common use, some of which have been rendered
+   obsolete by subsequent standards, but have never been clearly
+   deprecated in the context of the DNS.  In some cases there have been
+   interoperability problems between DNS implementations that support
+   these types and those that do not - for example, because of DNS name
+   compression in the wire format.  Continued support for these RR Types
+   imposes a complexity cost on new implementations for little benefit.
 
-2.  Deprecating MD, MF, MB, MG, MR, MINFO, MAILA, and MAILBRR Types
+   This document formally deprecates these RR Types, allowing
+   implementations to drop specific support for them.
 
-   The MD, MF, MB, MG, MR, MINFO, MAILA, and MAILB RR Types aren't used
-   in any existing standards, and this documents deprecates the usage.
-   The MD, MF, MB, MG, MR, and MINFO RR Types RDATA contain a domain
-   name that could be compressed in the RDATA section.
+2.  Deprecating MD, MF, MB, MG, MR, MINFO, MAILA, and MAILB RR Types
 
-   As an update to [RFC3597] and [RFC4034] this document specifies that
-   for MD, MF, MB, MG, MR, and MINFO RR types, the canonical form is
-   such that no downcasing of embedded domain names takes place, and
-   otherwise identical to the canonical form specified in [RFC4034]
-   section 6.2.
+   The MD, MF, MB, MG, MR, MINFO, MAILA, and MAILB RR Types are not used
+   in any existing standards, and this document deprecates their usage.
+
+   RDATA fields for MD, MF, MB, MG, MR, and MINFO RR Types contain
+   domain names.  DNS compression MUST NOT be applied to these domain
+   names when sending.
+
+   As an update to [RFC3597] and [RFC4034], this document updates the
+   specifications of the canonical forms for the MD, MF, MB, MG, MR, and
+   MINFO RR Types such that they do NOT include downcasing of embedded
+   domain names.  Canonical forms otherwise remain as specified in
+   [RFC4034] section 6.2.
+
+
+
+
+
+
+
+
+Sury                     Expires April 17, 2021                 [Page 2]
+
+Internet-Draft        Deprecating old mail RRTYPES          October 2020
+
 
 3.  IANA Considerations
 
    This documents updates the IANA registry "Domain Name System (DNS)
    Parameters" ([DNS-IANA]).
-
-
-
-
-
-
-
-
-
-Sury                   Expires September 27, 2018               [Page 2]
-
-Internet-Draft        Deprecating old mail RRTYPES            March 2018
-
 
               +-------+-------+------------+---------------+
               | TYPE  | Value | Meaning    | Reference     |
@@ -123,6 +128,8 @@ Internet-Draft        Deprecating old mail RRTYPES            March 2018
               | MG    | 8     | DEPRECATED | This document |
               | MR    | 9     | DEPRECATED | This document |
               | MINFO | 14    | DEPRECATED | This document |
+              | MAILB | 253   | DEPRECATED | This document |
+              | MAILA | 254   | DEPRECATED | This document |
               +-------+-------+------------+---------------+
 
 4.  Implementation Considerations
@@ -141,51 +148,48 @@ Internet-Draft        Deprecating old mail RRTYPES            March 2018
        DEPRECATED RR Types for received data for backward compatibility
        if desired, but SHOULD warn if such information is received.
        Compressed RDATA in DEPRECATED RR Types MUST be uncompressed
-       before sending and they MUST NOT be re-transmitted;
+       before sending, and MUST NOT be re-transmitted in compressed
+       form;
 
    4.  DNS Clients which receive DEPRECATED RR Types MAY interpret them
-       as unknown RR types ([RFC3597]), and MUST NOT interfere with
+       as unknown RR Types ([RFC3597]), and MUST NOT interfere with
        their transmission;
 
    5.  DNSSEC Validators and Signers SHOULD treat RDATA for DEPRECATED
        RR Types as opaque with respect to canonical RR ordering and
        deduplication;
 
-   6.  DEPRECATED RR Types MUST never be treated as a known-type with
-       respect to the wire protocol.
+
+
+
+
+
+
+Sury                     Expires April 17, 2021                 [Page 3]
+
+Internet-Draft        Deprecating old mail RRTYPES          October 2020
+
 
 5.  Security Considerations
 
-   This document has not security considerations.
-
-
-
-
-
-
-
-
-Sury                   Expires September 27, 2018               [Page 3]
-
-Internet-Draft        Deprecating old mail RRTYPES            March 2018
-
+   This document has no security considerations.
 
 6.  Operational Considerations
 
-   The various state of implementation of MB, MG, MR, MINFO, and WKS
-   records is already causing operational problems between DNS
-   implementations that do implement aforementioned types and those who
-   don't because of the DNS compression on the wire.  This document aims
-   to rectify the situation by removing the support for all these RR
-   types the DNS implementations.  This should not cause any operational
-   problems because the records aren't actually in use on the Internet.
-   [COMMENT: Some data?]
+   Varying states of implementation of MD, MF, MB, MG, MR, and MINFO RR
+   Types have already caused operational problems between DNS
+   implementations that do, and do not, implement them, as a result of
+   differing behavior with respect to DNS compression on the wire.  This
+   document aims to rectify the situation by encouraging removal of
+   support for all these RR types in DNS implementations.  This should
+   cause few if any operational problems, because these types are not in
+   use on the Internet.  [COMMENT: Some data?]
 
 7.  Acknowledgements
 
-   Peter van Dijk for poking me to write the draft.  Daniel Salzman for
-   reviewing the document.  Evan Hunt and Michael Casadevall to write
-   Implementation Considerations section.
+   Thanks to Peter van Dijk for prompting us to write the draft, Daniel
+   Salzman for reviewing, and Michael Casadevall for contributions to
+   the Implementation Considerations section.
 
 8.  References
 
@@ -208,8 +212,19 @@ Internet-Draft        Deprecating old mail RRTYPES            March 2018
 
    [DNS-IANA]
               "Domain Name System (DNS) Parameters",
-              <https://www.iana.org/assignments/dns-parameters/
-              dns-parameters.xhtml>.
+              <https://www.iana.org/assignments/dns-parameters/dns-
+              parameters.xhtml>.
+
+
+
+
+
+
+
+Sury                     Expires April 17, 2021                 [Page 4]
+
+Internet-Draft        Deprecating old mail RRTYPES          October 2020
+
 
 Author's Address
 
@@ -221,4 +236,45 @@ Author's Address
 
 
 
-Sury                   Expires September 27, 2018               [Page 4]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Sury                     Expires April 17, 2021                 [Page 5]

--- a/draft-sury-dnsop-deprecate-obsolete-resource-records.xml
+++ b/draft-sury-dnsop-deprecate-obsolete-resource-records.xml
@@ -30,15 +30,15 @@
         <email>ondrej@isc.org</email>
       </address>
     </author>
-    <date year="2018"/>
+    <date year="2020"/>
     <area>Ops</area>
     <workgroup>dnsop</workgroup>
     <keyword>Internet-Draft</keyword>
     <abstract>
       <t>
 	This document deprecates Resource Records (RR) Types that are
-	either not being used for anything meaningful or were been
-	already made obsolete by other RFCs.  This document updates
+	either not being used for anything meaningful or have already
+	been rendered obsolete by other RFCs.  This document updates
 	<xref target="RFC1035"/>, <xref target="RFC1035"/>, <xref
 	target="RFC4034"/>.
       </t>
@@ -49,7 +49,7 @@
 
     <section anchor="introduction" title="Introduction">
       <t>
-	<xref target="RFC1035"/> and other documents have defined some
+	<xref target="RFC1035"/> and other documents defined some
 	Resource Record (RR) Types that are no longer in common use,
 	some of which have been rendered obsolete by subsequent standards,
 	but have never been clearly deprecated in the context of the DNS.
@@ -60,27 +60,31 @@
 	complexity cost on new implementations for little benefit.
       </t>
       <t>
-	This document formally deprecates such RR Types, allowing
+	This document formally deprecates these RR Types, allowing
 	implementations to drop specific support for them.
       </t>
     </section>
 
-    <section title="Deprecating MD, MF, MB, MG, MR, MINFO, MAILA, and MAILBRR Types">
+    <section title="Deprecating MD, MF, MB, MG, MR, MINFO, MAILA, and MAILB RR Types">
       <t>
 	The MD, MF, MB, MG, MR, MINFO, MAILA, and MAILB RR Types
-	aren't used in any existing standards, and this documents
-	deprecates their usage.  The MD, MF, MB, MG, MR, and MINFO RR
-	Types RDATA contain a domain name that could be compressed in
-	the RDATA section.
+	are not used in any existing standards, and this document
+	deprecates their usage.
       </t>
 
       <t>
-	As an update to <xref target="RFC3597"/> and <xref
-	target="RFC4034"/> this document specifies that for MD, MF,
-	MB, MG, MR, and MINFO RR types, the canonical form is such
-	that no downcasing of embedded domain names takes place, and
-	is otherwise identical to the canonical form specified in <xref
-	target="RFC4034"/> section 6.2.
+	RDATA fields for MD, MF, MB, MG, MR, and MINFO RR Types
+	contain domain names.  DNS compression MUST NOT be applied
+	to these domain names when sending.
+      </t>
+
+      <t>
+	As an update to <xref target="RFC3597"/> and
+	<xref target="RFC4034"/>, this document updates the specifications
+	of the canonical forms for the MD, MF, MB, MG, MR, and MINFO
+	RR Types such that they do NOT include downcasing of embedded
+	domain names. Canonical forms otherwise remain as specified
+	in <xref target="RFC4034"/> section 6.2.
       </t>
     </section>
 
@@ -95,6 +99,8 @@
 	<c>MG</c>               <c>8</c>                  <c>DEPRECATED</c> <c>This document</c>
 	<c>MR</c>               <c>9</c>                  <c>DEPRECATED</c> <c>This document</c>
 	<c>MINFO</c>            <c>14</c>                 <c>DEPRECATED</c> <c>This document</c>
+	<c>MAILB</c>            <c>253</c>                <c>DEPRECATED</c> <c>This document</c>
+	<c>MAILA</c>            <c>254</c>                <c>DEPRECATED</c> <c>This document</c>
       </texttable>
     </section>
 
@@ -120,13 +126,13 @@
 	      DEPRECATED RR Types for received data for backward
 	      compatibility if desired, but SHOULD warn if such
 	      information is received.  Compressed RDATA in DEPRECATED
-	      RR Types MUST be uncompressed before sending and they
-	      MUST NOT be re-transmitted;
+	      RR Types MUST be uncompressed before sending, and
+	      MUST NOT be re-transmitted in compressed form;
 	    </t>
 	    
 	    <t>
 	      DNS Clients which receive DEPRECATED RR Types MAY
-	      interpret them as unknown RR types (<xref
+	      interpret them as unknown RR Types (<xref
 	      target="RFC3597"/>), and MUST NOT interfere with their
 	      transmission;
 	    </t>
@@ -135,11 +141,6 @@
 	      DNSSEC Validators and Signers SHOULD treat RDATA for
 	      DEPRECATED RR Types as opaque with respect to canonical
 	      RR ordering and deduplication;
-	    </t>
-
-	    <t>
-	      DEPRECATED RR Types MUST never be treated as a
-	      known-type with respect to the wire protocol.
 	    </t>
 	  </list>
       </t>
@@ -153,22 +154,23 @@
 
     <section anchor="operation" title="Operational Considerations">
       <t>
-	The varying states of implementation of MD, MF, MB, MG,
-	MR, and MINFO RR Types has already caused operational problems
-	between DNS implementations that do implement the aforementioned
-	types and those that don't because of DNS compression on the wire.
-	This document aims to rectify the situation by encouraging removal
-	of support for all these RR types in DNS implementations.  This
-	should not cause signficant operational problems because these
-	records are not in wide use on the Internet. [COMMENT: Some data?]
+	Varying states of implementation of MD, MF, MB, MG, MR, and
+	MINFO RR Types have already caused operational problems
+	between DNS implementations that do, and do not, implement them,
+	as a result of differing behavior with respect to DNS compression
+	on the wire.  This document aims to rectify the situation by
+	encouraging removal of support for all these RR types in DNS
+	implementations.  This should cause few if any operational
+	problems, because these types are not in use on the Internet.
+	[COMMENT: Some data?]
       </t>
     </section>
 
     <section anchor="ack" title="Acknowledgements">
       <t>
-	Peter van Dijk for poking me to write the draft.  Daniel
-	Salzman for reviewing the document.  Evan Hunt and Michael
-	Casadevall to write Implementation Considerations section.
+	Thanks to Peter van Dijk for prompting us to write the draft,
+	Daniel Salzman for reviewing, and Michael Casadevall for
+	contributions to the Implementation Considerations section.
       </t>
     </section>
 


### PR DESCRIPTION
made some more grammar and style changes; removed item 6 in the implementation considerations section as, after rewriting it for more clarity, it seemed to be redundant - all the changes that would be needed to treat the deprecated RR types as unknown types for wire format purposes were already specified in other sections.

also added a Makefile to generate an updated txt version. could do that in a separate PR if you prefer.