### PR TITLE
convert to markdown, plus minor revisions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+MMARK=${GOPATH}/bin/mmark
+
+DRAFT=draft-sury-dnsop-deprecate-obsolete-resource-records
+
+OUT= ${DRAFT}.xml ${DRAFT}.html ${DRAFT}.txt
+
+all: ${OUT}
+
+${DRAFT}.xml: ${DRAFT}.md
+	${MMARK} ${DRAFT}.md >${DRAFT}.xml
+
+${DRAFT}.html: ${DRAFT}.md
+	xml2rfc --v3 --html -o ${DRAFT}.html ${DRAFT}.xml
+
+${DRAFT}.txt: ${DRAFT}.xml
+	xml2rfc --v3 --text ${DRAFT}.xml
+
+commit: stamp ${OUT}
+	git add ${OUT}
+	git commit -m 'Update rendered versions'
+
+stamp::
+	./util/stamp ${DRAFT}.md
+
+clean:
+	rm -f ${OUT}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+Deprecating Obsolete DNS Resource Record Types
+==============================================
+
+The canonical version of this repository is
+
+  * https://github.com/oerdnj/draft-sury-dnsop-deprecate-obsolete-resource-records
+
+The markdown source is converted to RFC XML format using `mmark`
+
+  * https://github.com/mmarkdown/mmark
+
+  * https://mmark.nl/

--- a/draft-sury-dnsop-deprecate-obsolete-resource-records.html
+++ b/draft-sury-dnsop-deprecate-obsolete-resource-records.html
@@ -1,0 +1,1480 @@
+<!DOCTYPE html>
+<html lang="en" class="Internet-Draft">
+<head>
+<meta charset="utf-8">
+<meta content="Common,Latin" name="scripts">
+<meta content="initial-scale=1.0" name="viewport">
+<title>Deprecating Obsolete DNS Resource Record Types</title>
+<meta content="Ondřej Surý" name="author">
+<meta content="Evan Hunt" name="author">
+<meta content="
+       This document deprecates Resource Record (RR) Types that are
+either no longer being used for anything meaningful or have
+been made obsolete by other RFCs.  This document updates
+ ,  ,  , and  . 
+    " name="description">
+<meta content="xml2rfc 2.40.0" name="generator">
+<meta content="DNS" name="keyword">
+<meta content="RRTYPE" name="keyword">
+<meta content="RR" name="keyword">
+<meta content="draft-sury-dnsop-deprecate-obsolete-resource-records-02" name="ietf.draft">
+<link href="draft-sury-dnsop-deprecate-obsolete-resource-records.xml" rel="alternate" type="application/rfc+xml">
+<link href="#copyright" rel="license">
+<style type="text/css">/*
+
+  NOTE: Changes at the bottom of this file overrides some earlier settings.
+
+  Once the style has stabilized and has been adopted as an official RFC style,
+  this can be consolidated so that style settings occur only in one place, but
+  for now the contents of this file consists first of the initial CSS work as
+  provided to the RFC Formatter (xml2rfc) work, followed by itemized and
+  commented changes found necssary during the development of the v3
+  formatters.
+
+*/
+
+/* fonts */
+@import url('https://fonts.googleapis.com/css?family=Noto+Sans'); /* Sans-serif */
+@import url('https://fonts.googleapis.com/css?family=Noto+Serif'); /* Serif (print) */
+@import url('https://fonts.googleapis.com/css?family=Roboto+Mono'); /* Monospace */
+
+@viewport {
+  zoom: 1.0;
+  width: extend-to-zoom;
+}
+@-ms-viewport {
+  width: extend-to-zoom;
+  zoom: 1.0;
+}
+/* general and mobile first */
+html {
+}
+body {
+  max-width: 90%;
+  margin: 1.5em auto;
+  color: #222;
+  background-color: #fff;
+  font-size: 14px;
+  font-family: 'Noto Sans', Arial, Helvetica, sans-serif;
+  line-height: 1.6;
+  scroll-behavior: smooth;
+}
+.ears {
+  display: none;
+}
+
+/* headings */
+#title, h1, h2, h3, h4, h5, h6 {
+  margin: 1em 0 0.5em;
+  font-weight: bold;
+  line-height: 1.3;
+}
+#title {
+  clear: both;
+  border-bottom: 1px solid #ddd;
+  margin: 0 0 0.5em 0;
+  padding: 1em 0 0.5em;
+}
+.author {
+  padding-bottom: 4px;
+}
+h1 {
+  font-size: 26px;
+  margin: 1em 0;
+}
+h2 {
+  font-size: 22px;
+  margin-top: -20px;  /* provide offset for in-page anchors */
+  padding-top: 33px;
+}
+h3 {
+  font-size: 18px;
+  margin-top: -36px;  /* provide offset for in-page anchors */
+  padding-top: 42px;
+}
+h4 {
+  font-size: 16px;
+  margin-top: -36px;  /* provide offset for in-page anchors */
+  padding-top: 42px;
+}
+h5, h6 {
+  font-size: 14px;
+}
+#n-copyright-notice {
+  border-bottom: 1px solid #ddd;
+  padding-bottom: 1em;
+  margin-bottom: 1em;
+}
+/* general structure */
+p {
+  padding: 0;
+  margin: 0 0 1em 0;
+  text-align: left;
+}
+div, span {
+  position: relative;
+}
+div {
+  margin: 0;
+}
+.alignRight.art-text {
+  background-color: #f9f9f9;
+  border: 1px solid #eee;
+  border-radius: 3px;
+  padding: 1em 1em 0;
+  margin-bottom: 1.5em;
+}
+.alignRight.art-text pre {
+  padding: 0;
+}
+.alignRight {
+  margin: 1em 0;
+}
+.alignRight > *:first-child {
+  border: none;
+  margin: 0;
+  float: right;
+  clear: both;
+}
+.alignRight > *:nth-child(2) {
+  clear: both;
+  display: block;
+  border: none;
+}
+svg {
+  display: block;
+}
+.alignCenter.art-text {
+  background-color: #f9f9f9;
+  border: 1px solid #eee;
+  border-radius: 3px;
+  padding: 1em 1em 0;
+  margin-bottom: 1.5em;
+}
+.alignCenter.art-text pre {
+  padding: 0;
+}
+.alignCenter {
+  margin: 1em 0;
+}
+.alignCenter > *:first-child {
+  border: none;
+  /* this isn't optimal, but it's an existence proof.  PrinceXML doesn't
+     support flexbox yet.
+  */
+  display: table;
+  margin: 0 auto;
+}
+
+/* lists */
+ol, ul {
+  padding: 0;
+  margin: 0 0 1em 2em;
+}
+ol ol, ul ul, ol ul, ul ol {
+  margin-left: 1em;
+}
+li {
+  margin: 0 0 0.25em 0;
+}
+.ulCompact li {
+  margin: 0;
+}
+ul.empty, .ulEmpty {
+  list-style-type: none;
+}
+ul.empty li, .ulEmpty li {
+  margin-top: 0.5em;
+}
+ul.compact, .ulCompact,
+ol.compact, .olCompact {
+  line-height: 100%;
+  margin: 0 0 0 2em;
+}
+
+/* definition lists */
+dl {
+}
+dl > dt {
+  float: left;
+  margin-right: 1em;
+}
+/* 
+dl.nohang > dt {
+  float: none;
+}
+*/
+dl > dd {
+  margin-bottom: .8em;
+  min-height: 1.3em;
+}
+dl.compact > dd, .dlCompact > dd {
+  margin-bottom: 0em;
+}
+dl > dd > dl {
+  margin-top: 0.5em;
+  margin-bottom: 0em;
+}
+
+/* links */
+a {
+  text-decoration: none;
+}
+a[href] {
+  color: #22e; /* Arlen: WCAG 2019 */
+}
+a[href]:hover {
+  background-color: #f2f2f2;
+}
+figcaption a[href],
+a[href].selfRef {
+  color: #222;
+}
+/* XXX probably not this:
+a.selfRef:hover {
+  background-color: transparent;
+  cursor: default;
+} */
+
+/* Figures */
+tt, code, pre, code {
+  background-color: #f9f9f9;
+  font-family: 'Roboto Mono', monospace;
+}
+pre {
+  border: 1px solid #eee;
+  margin: 0;
+  padding: 1em;
+}
+img {
+  max-width: 100%;
+}
+figure {
+  margin: 0;
+}
+figure blockquote {
+  margin: 0.8em 0.4em 0.4em;
+}
+figcaption {
+  font-style: italic;
+  margin: 0 0 1em 0;
+}
+@media screen {
+  pre {
+    overflow-x: auto;
+    max-width: 100%;
+    max-width: calc(100% - 22px);
+  }
+}
+
+/* aside, blockquote */
+aside, blockquote {
+  margin-left: 0;
+  padding: 1.2em 2em;
+}
+blockquote {
+  background-color: #f9f9f9;
+  color: #111; /* Arlen: WCAG 2019 */
+  border: 1px solid #ddd;
+  border-radius: 3px;
+  margin: 1em 0;
+}
+cite {
+  display: block;
+  text-align: right;
+  font-style: italic;
+}
+
+/* tables */
+table {
+  width: 100%;
+  margin: 0 0 1em;
+  border-collapse: collapse;
+  border: 1px solid #eee;
+}
+th, td {
+  text-align: left;
+  vertical-align: top;
+  padding: 0.5em 0.75em;
+}
+th {
+  text-align: left;
+  background-color: #e9e9e9;
+}
+tr:nth-child(2n+1) > td {
+  background-color: #f5f5f5;
+}
+table caption {
+  font-style: italic;
+  margin: 0;
+  padding: 0;
+  text-align: left;
+}
+table p {
+  /* XXX to avoid bottom margin on table row signifiers. If paragraphs should
+     be allowed within tables more generally, it would be far better to select on a class. */
+  margin: 0;
+}
+
+/* pilcrow */
+a.pilcrow {
+  color: #666; /* Arlen: AHDJ 2019 */
+  text-decoration: none;
+  visibility: hidden;
+  user-select: none;
+  -ms-user-select: none;
+  -o-user-select:none;
+  -moz-user-select: none;
+  -khtml-user-select: none;
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
+}
+@media screen {
+  aside:hover > a.pilcrow,
+  p:hover > a.pilcrow,
+  blockquote:hover > a.pilcrow,
+  div:hover > a.pilcrow,
+  li:hover > a.pilcrow,
+  pre:hover > a.pilcrow {
+    visibility: visible;
+  }
+  a.pilcrow:hover {
+    background-color: transparent;
+  }
+}
+
+/* misc */
+hr {
+  border: 0;
+  border-top: 1px solid #eee;
+}
+.bcp14 {
+  font-variant: small-caps;
+}
+
+.role {
+  font-variant: all-small-caps;
+}
+
+/* info block */
+#identifiers {
+  margin: 0;
+  font-size: 0.9em;
+}
+#identifiers dt {
+  width: 3em;
+  clear: left;
+}
+#identifiers dd {
+  float: left;
+  margin-bottom: 0;
+}
+#identifiers .authors .author {
+  display: inline-block;
+  margin-right: 1.5em;
+}
+#identifiers .authors .org {
+  font-style: italic;
+}
+
+/* The prepared/rendered info at the very bottom of the page */
+.docInfo {
+  color: #666; /* Arlen: WCAG 2019 */
+  font-size: 0.9em;
+  font-style: italic;
+  margin-top: 2em;
+}
+.docInfo .prepared {
+  float: left;
+}
+.docInfo .prepared {
+  float: right;
+}
+
+/* table of contents */
+#toc  {
+  padding: 0.75em 0 2em 0;
+  margin-bottom: 1em;
+}
+nav.toc ul {
+  margin: 0 0.5em 0 0;
+  padding: 0;
+  list-style: none;
+}
+nav.toc li {
+  line-height: 1.3em;
+  margin: 0.75em 0;
+  padding-left: 1.2em;
+  text-indent: -1.2em;
+}
+/* references */
+.references dt {
+  text-align: right;
+  font-weight: bold;
+  min-width: 7em;
+}
+.references dd {
+  margin-left: 8em;
+  overflow: auto;
+}
+
+.refInstance {
+  margin-bottom: 1.25em;
+}
+
+.references .ascii {
+  margin-bottom: 0.25em;
+}
+
+/* index */
+.index ul {
+  margin: 0 0 0 1em;
+  padding: 0;
+  list-style: none;
+}
+.index ul ul {
+  margin: 0;
+}
+.index li {
+  margin: 0;
+  text-indent: -2em;
+  padding-left: 2em;
+  padding-bottom: 5px;
+}
+.indexIndex {
+  margin: 0.5em 0 1em;
+}
+.index a {
+  font-weight: 700;
+}
+/* make the index two-column on all but the smallest screens */
+@media (min-width: 600px) {
+  .index ul {
+    -moz-column-count: 2;
+    -moz-column-gap: 20px;
+  }
+  .index ul ul {
+    -moz-column-count: 1;
+    -moz-column-gap: 0;
+  }
+}
+
+/* authors */
+address.vcard {
+  font-style: normal;
+  margin: 1em 0;
+}
+
+address.vcard .nameRole {
+  font-weight: 700;
+  margin-left: 0;
+}
+address.vcard .label {
+  font-family: "Noto Sans",Arial,Helvetica,sans-serif;
+  margin: 0.5em 0;
+}
+address.vcard .type {
+  display: none;
+}
+.alternative-contact {
+  margin: 1.5em 0 1em;
+}
+hr.addr {
+  border-top: 1px dashed;
+  margin: 0;
+  color: #ddd;
+  max-width: calc(100% - 16px);
+}
+
+/* temporary notes */
+.rfcEditorRemove::before {
+  position: absolute;
+  top: 0.2em;
+  right: 0.2em;
+  padding: 0.2em;
+  content: "The RFC Editor will remove this note";
+  color: #9e2a00; /* Arlen: WCAG 2019 */
+  background-color: #ffd; /* Arlen: WCAG 2019 */
+}
+.rfcEditorRemove {
+  position: relative;
+  padding-top: 1.8em;
+  background-color: #ffd; /* Arlen: WCAG 2019 */
+  border-radius: 3px;
+}
+.cref {
+  background-color: #ffd; /* Arlen: WCAG 2019 */
+  padding: 2px 4px;
+}
+.crefSource {
+  font-style: italic;
+}
+/* alternative layout for smaller screens */
+@media screen and (max-width: 1023px) {
+  body {
+    padding-top: 2em;
+  }
+  #title {
+    padding: 1em 0;
+  }
+  h1 {
+    font-size: 24px;
+  }
+  h2 {
+    font-size: 20px;
+    margin-top: -18px;  /* provide offset for in-page anchors */
+    padding-top: 38px;
+  }
+  #identifiers dd {
+    max-width: 60%;
+  }
+  #toc {
+    position: fixed;
+    z-index: 2;
+    top: 0;
+    right: 0;
+    padding: 0;
+    margin: 0;
+    background-color: inherit;
+    border-bottom: 1px solid #ccc;
+  }
+  #toc h2 {
+    margin: -1px 0 0 0;
+    padding: 4px 0 4px 6px;
+    padding-right: 1em;
+    min-width: 190px;
+    font-size: 1.1em;
+    text-align: right;
+    background-color: #444;
+    color: white;
+    cursor: pointer;
+  }
+  #toc h2::before { /* css hamburger */
+    float: right;
+    position: relative;
+    width: 1em;
+    height: 1px;
+    left: -164px;
+    margin: 6px 0 0 0;
+    background: white none repeat scroll 0 0;
+    box-shadow: 0 4px 0 0 white, 0 8px 0 0 white;
+    content: "";
+  }
+  #toc nav {
+    display: none;
+    padding: 0.5em 1em 1em;
+    overflow: auto;
+    height: calc(100vh - 48px);
+    border-left: 1px solid #ddd;
+  }
+}
+
+/* alternative layout for wide screens */
+@media screen and (min-width: 1024px) {
+  body {
+    max-width: 724px;
+    margin: 42px auto;
+    padding-left: 1.5em;
+    padding-right: 29em;
+  }
+  #toc {
+    position: fixed;
+    top: 42px;
+    right: 42px;
+    width: 25%;
+    margin: 0;
+    padding: 0 1em;
+    z-index: 1;
+  }
+  #toc h2 {
+    border-top: none;
+    border-bottom: 1px solid #ddd;
+    font-size: 1em;
+    font-weight: normal;
+    margin: 0;
+    padding: 0.25em 1em 1em 0;
+  }
+  #toc nav {
+    display: block;
+    height: calc(90vh - 84px);
+    bottom: 0;
+    padding: 0.5em 0 0;
+    overflow: auto;
+  }
+  img { /* future proofing */
+    max-width: 100%;
+    height: auto;
+  }
+}
+
+/* pagination */
+@media print {
+  body {
+
+    width: 100%;
+  }
+  p {
+    orphans: 3;
+    widows: 3;
+  }
+  #n-copyright-notice {
+    border-bottom: none;
+  }
+  #toc, #n-introduction {
+    page-break-before: always;
+  }
+  #toc {
+    border-top: none;
+    padding-top: 0;
+  }
+  figure, pre {
+    page-break-inside: avoid;
+  }
+  figure {
+    overflow: scroll;
+  }
+  h1, h2, h3, h4, h5, h6 {
+    page-break-after: avoid;
+  }
+  h2+*, h3+*, h4+*, h5+*, h6+* {
+    page-break-before: avoid;
+  }
+  pre {
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    font-size: 10pt;
+  }
+  table {
+    border: 1px solid #ddd;
+  }
+  td {
+    border-top: 1px solid #ddd;
+  }
+}
+
+/* This is commented out here, as the string-set: doesn't
+   pass W3C validation currently */
+/*
+.ears thead .left {
+  string-set: ears-top-left content();
+}
+
+.ears thead .center {
+  string-set: ears-top-center content();
+}
+
+.ears thead .right {
+  string-set: ears-top-right content();
+}
+
+.ears tfoot .left {
+  string-set: ears-bottom-left content();
+}
+
+.ears tfoot .center {
+  string-set: ears-bottom-center content();
+}
+
+.ears tfoot .right {
+  string-set: ears-bottom-right content();
+}
+*/
+
+@page :first {
+  padding-top: 0;
+  @top-left {
+    content: normal;
+    border: none;
+  }
+  @top-center {
+    content: normal;
+    border: none;
+  }
+  @top-right {
+    content: normal;
+    border: none;
+  }
+}
+
+@page {
+  size: A4;
+  margin-bottom: 45mm;
+  padding-top: 20px;
+  /* The follwing is commented out here, but set appropriately by in code, as
+     the content depends on the document */
+  /*
+  @top-left {
+    content: 'Internet-Draft';
+    vertical-align: bottom;
+    border-bottom: solid 1px #ccc;
+  }
+  @top-left {
+    content: string(ears-top-left);
+    vertical-align: bottom;
+    border-bottom: solid 1px #ccc;
+  }
+  @top-center {
+    content: string(ears-top-center);
+    vertical-align: bottom;
+    border-bottom: solid 1px #ccc;
+  }
+  @top-right {
+    content: string(ears-top-right);
+    vertical-align: bottom;
+    border-bottom: solid 1px #ccc;
+  }
+  @bottom-left {
+    content: string(ears-bottom-left);
+    vertical-align: top;
+    border-top: solid 1px #ccc;
+  }
+  @bottom-center {
+    content: string(ears-bottom-center);
+    vertical-align: top;
+    border-top: solid 1px #ccc;
+  }
+  @bottom-right {
+      content: '[Page ' counter(page) ']';
+      vertical-align: top;
+      border-top: solid 1px #ccc;
+  }
+  */
+
+}
+
+/* Changes introduced to fix issues found during implementation */
+/* Make sure links are clickable even if overlapped by following H* */
+a {
+  z-index: 2;
+}
+/* Separate body from document info even without intervening H1 */
+section {
+  clear: both;
+}
+
+
+/* Top align author divs, to avoid names without organization dropping level with org names */
+.author {
+  vertical-align: top;
+}
+
+/* Leave room in document info to show Internet-Draft on one line */
+#identifiers dt {
+  width: 8em;
+}
+
+/* Don't waste quite as much whitespace between label and value in doc info */
+#identifiers dd {
+  margin-left: 1em;
+}
+
+/* Give floating toc a background color (needed when it's a div inside section */
+#toc {
+  background-color: white;
+}
+
+/* Make the collapsed ToC header render white on gray also when it's a link */
+@media screen and (max-width: 1023px) {
+  #toc h2 a,
+  #toc h2 a:link,
+  #toc h2 a:focus,
+  #toc h2 a:hover,
+  #toc a.toplink,
+  #toc a.toplink:hover {
+    color: white;
+    background-color: #444;
+    text-decoration: none;
+  }
+}
+
+/* Give the bottom of the ToC some whitespace */
+@media screen and (min-width: 1024px) {
+  #toc {
+    padding: 0 0 1em 1em;
+  }
+}
+
+/* Style section numbers with more space between number and title */
+.section-number {
+  padding-right: 0.5em;
+}
+
+/* prevent monospace from becoming overly large */
+tt, code, pre, code {
+  font-size: 95%;
+}
+
+/* Fix the height/width aspect for ascii art*/
+pre.sourcecode,
+.art-text pre {
+  line-height: 1.12;
+}
+
+
+/* Add styling for a link in the ToC that points to the top of the document */
+a.toplink {
+  float: right;
+  margin-right: 0.5em;
+}
+
+/* Fix the dl styling to match the RFC 7992 attributes */
+dl > dt,
+dl.dlParallel > dt {
+  float: left;
+  margin-right: 1em;
+}
+dl.dlNewline > dt {
+  float: none;
+}
+
+/* Provide styling for table cell text alignment */
+table td.text-left,
+table th.text-left {
+  text-align: left;
+}
+table td.text-center,
+table th.text-center {
+  text-align: center;
+}
+table td.text-right,
+table th.text-right {
+  text-align: right;
+}
+
+/* Make the alternative author contact informatio look less like just another
+   author, and group it closer with the primary author contact information */
+.alternative-contact {
+  margin: 0.5em 0 0.25em 0;
+}
+address .non-ascii {
+  margin: 0 0 0 2em;
+}
+
+/* With it being possible to set tables with alignment
+  left, center, and right, { width: 100%; } does not make sense */
+table {
+  width: auto;
+}
+
+/* Avoid reference text that sits in a block with very wide left margin,
+   because of a long floating dt label.*/
+.references dd {
+  overflow: visible;
+}
+
+/* Control caption placement */
+caption {
+  caption-side: bottom;
+}
+
+/* Limit the width of the author address vcard, so names in right-to-left
+   script don't end up on the other side of the page. */
+
+address.vcard {
+  max-width: 30em;
+  margin-right: auto;
+}
+
+/* For address alignment dependent on LTR or RTL scripts */
+address div.left {
+  text-align: left;
+}
+address div.right {
+  text-align: right;
+}
+
+/* Provide table alignment support.  We can't use the alignX classes above
+   since they do unwanted things with caption and other styling. */
+table.right {
+ margin-left: auto;
+ margin-right: 0;
+}
+table.center {
+ margin-left: auto;
+ margin-right: auto;
+}
+table.left {
+ margin-left: 0;
+ margin-right: auto;
+}
+
+/* Give the table caption label the same styling as the figcaption */
+caption a[href] {
+  color: #222;
+}
+
+@media print {
+  .toplink {
+    display: none;
+  }
+
+  /* avoid overwriting the top border line with the ToC header */
+  #toc {
+    padding-top: 1px;
+  }
+
+  /* Avoid page breaks inside dl and author address entries */
+  .vcard {
+    page-break-inside: avoid;
+  }
+
+}
+/* Avoid wrapping of URLs in references */
+@media screen {
+  .references a {
+    white-space: nowrap;
+  }
+}
+/* Tweak the bcp14 keyword presentation */
+.bcp14 {
+  font-variant: small-caps;
+  font-weight: bold;
+  font-size: 0.9em;
+}
+/* Tweak the invisible space above H* in order not to overlay links in text above */
+ h2 {
+  margin-top: -18px;  /* provide offset for in-page anchors */
+  padding-top: 31px;
+ }
+ h3 {
+  margin-top: -18px;  /* provide offset for in-page anchors */
+  padding-top: 24px;
+ }
+ h4 {
+  margin-top: -18px;  /* provide offset for in-page anchors */
+  padding-top: 24px;
+ }
+/* Float artwork pilcrow to the right */
+@media screen {
+  .artwork a.pilcrow {
+    display: block;
+    line-height: 0.7;
+    margin-top: 0.15em;
+  }
+}
+/* Make pilcrows on dd visible */
+@media screen {
+  dd:hover > a.pilcrow {
+    visibility: visible;
+  }
+}
+/* Make the placement of figcaption match that of a table's caption
+   by removing the figure's added bottom margin */
+.alignLeft.art-text,
+.alignCenter.art-text,
+.alignRight.art-text {
+   margin-bottom: 0;
+}
+.alignLeft,
+.alignCenter,
+.alignRight {
+  margin: 1em 0 0 0;
+}
+/* In print, the pilcrow won't show on hover, so prevent it from taking up space,
+   possibly even requiring a new line */
+@media print {
+  a.pilcrow {
+    display: none;
+  }
+}
+/* Styling for the external metadata */
+div#external-metadata {
+  background-color: #eee;
+  padding: 0.5em;
+  margin-bottom: 0.5em;
+  display: none;
+}
+div#internal-metadata {
+  padding: 0.5em;                       /* to match the external-metadata padding */
+}
+/* Styling for title RFC Number */
+h1#rfcnum {
+  clear: both;
+  margin: 0 0 -1em;
+  padding: 1em 0 0 0;
+}
+/* Make .olPercent look the same as <ol><li> */
+dl.olPercent > dd {
+  margin: 0 0 0.25em 0;
+  min-height: initial;
+}
+/* Give aside some styling to set it apart */
+aside {
+  border-left: 1px solid #ddd;
+  margin: 1em 0 1em 2em;
+  padding: 0.2em 2em;
+}
+aside > dl,
+aside > ol,
+aside > ul,
+aside > table,
+aside > p {
+  margin-bottom: 0.5em;
+}
+/* Additional page break settings */
+@media print {
+  figcaption, table caption {
+    page-break-before: avoid;
+  }
+}
+/* Font size adjustments for print */
+@media print {
+  body  { font-size: 10pt;      line-height: normal; max-width: 96%; }
+  h1    { font-size: 1.72em;    padding-top: 1.5em; } /* 1*1.2*1.2*1.2 */
+  h2    { font-size: 1.44em;    padding-top: 1.5em; } /* 1*1.2*1.2 */
+  h3    { font-size: 1.2em;     padding-top: 1.5em; } /* 1*1.2 */
+  h4    { font-size: 1em;       padding-top: 1.5em; }
+  h5, h6 { font-size: 1em;      margin: initial; padding: 0.5em 0 0.3em; }
+}
+/* Sourcecode margin in print, when there's no pilcrow */
+@media print {
+  .artwork,
+  .sourcecode {
+    margin-bottom: 1em;
+  }
+}
+/*
+  The margin-left: 0 on <dd> removes all distinction
+  between levels from nested <dl>s.  Undo that.
+*/
+dl.olPercent > dd,
+dd {
+  margin-left: revert;
+}
+/* Avoid narrow tables forcing too narrow table captions, which may render badly */
+table {
+  min-width: 20em;
+}
+/* ol type a */
+ol.type-a { list-style-type: lower-alpha; }
+ol.type-A { list-style-type: upper-alpha; }
+ol.type-i { list-style-type: lower-roman; }
+ol.type-I { list-style-type: lower-roman; }
+</style>
+<link href="rfc-local.css" rel="stylesheet" type="text/css">
+</head>
+<body>
+<script src="metadata.min.js"></script>
+<table class="ears">
+<thead><tr>
+<td class="left">Internet-Draft</td>
+<td class="center">Deprecating RRTYPEs</td>
+<td class="right">April 2021</td>
+</tr></thead>
+<tfoot><tr>
+<td class="left">Sury &amp; Hunt</td>
+<td class="center">Expires 16 October 2021</td>
+<td class="right">[Page]</td>
+</tr></tfoot>
+</table>
+<div id="external-metadata" class="document-information"></div>
+<div id="internal-metadata" class="document-information">
+<dl id="identifiers">
+<dt class="label-workgroup">Workgroup:</dt>
+<dd class="workgroup">DNS Operations</dd>
+<dt class="label-internet-draft">Internet-Draft:</dt>
+<dd class="internet-draft">draft-sury-dnsop-deprecate-obsolete-resource-records-02</dd>
+<dt class="label-updates">Updates:</dt>
+<dd class="updates">
+<a href="https://www.rfc-editor.org/rfc/rfc1034" class="eref">1034</a>, <a href="https://www.rfc-editor.org/rfc/rfc1035" class="eref">1035</a>, <a href="https://www.rfc-editor.org/rfc/rfc3597" class="eref">3597</a>, <a href="https://www.rfc-editor.org/rfc/rfc4034" class="eref">4034</a> (if approved)</dd>
+<dt class="label-published">Published:</dt>
+<dd class="published">
+<time datetime="2021-04-14" class="published">14 April 2021</time>
+    </dd>
+<dt class="label-intended-status">Intended Status:</dt>
+<dd class="intended-status">Standards Track</dd>
+<dt class="label-expires">Expires:</dt>
+<dd class="expires"><time datetime="2021-10-16">16 October 2021</time></dd>
+<dt class="label-authors">Authors:</dt>
+<dd class="authors">
+<div class="author">
+      <div class="author-name">O. Sury</div>
+<div class="org">ISC</div>
+</div>
+<div class="author">
+      <div class="author-name">E. Hunt</div>
+<div class="org">ISC</div>
+</div>
+</dd>
+</dl>
+</div>
+<h1 id="title">Deprecating Obsolete DNS Resource Record Types</h1>
+<section id="section-abstract">
+      <h2 id="abstract"><a href="#abstract" class="selfRef">Abstract</a></h2>
+<p id="section-abstract-1">This document deprecates Resource Record (RR) Types that are
+either no longer being used for anything meaningful or have
+been made obsolete by other RFCs.  This document updates
+<span>[<a href="#RFC1034" class="xref">RFC1034</a>]</span>, <span>[<a href="#RFC1035" class="xref">RFC1035</a>]</span>, <span>[<a href="#RFC3597" class="xref">RFC3597</a>]</span>, and <span>[<a href="#RFC4034" class="xref">RFC4034</a>]</span>.<a href="#section-abstract-1" class="pilcrow">¶</a></p>
+</section>
+<div id="status-of-memo">
+<section id="section-boilerplate.1">
+        <h2 id="name-status-of-this-memo">
+<a href="#name-status-of-this-memo" class="section-name selfRef">Status of This Memo</a>
+        </h2>
+<p id="section-boilerplate.1-1">
+        This Internet-Draft is submitted in full conformance with the
+        provisions of BCP 78 and BCP 79.<a href="#section-boilerplate.1-1" class="pilcrow">¶</a></p>
+<p id="section-boilerplate.1-2">
+        Internet-Drafts are working documents of the Internet Engineering Task
+        Force (IETF). Note that other groups may also distribute working
+        documents as Internet-Drafts. The list of current Internet-Drafts is
+        at <span><a href="https://datatracker.ietf.org/drafts/current/">https://datatracker.ietf.org/drafts/current/</a></span>.<a href="#section-boilerplate.1-2" class="pilcrow">¶</a></p>
+<p id="section-boilerplate.1-3">
+        Internet-Drafts are draft documents valid for a maximum of six months
+        and may be updated, replaced, or obsoleted by other documents at any
+        time. It is inappropriate to use Internet-Drafts as reference
+        material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
+<p id="section-boilerplate.1-4">
+        This Internet-Draft will expire on 16 October 2021.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="copyright">
+<section id="section-boilerplate.2">
+        <h2 id="name-copyright-notice">
+<a href="#name-copyright-notice" class="section-name selfRef">Copyright Notice</a>
+        </h2>
+<p id="section-boilerplate.2-1">
+            Copyright (c) 2021 IETF Trust and the persons identified as the
+            document authors. All rights reserved.<a href="#section-boilerplate.2-1" class="pilcrow">¶</a></p>
+<p id="section-boilerplate.2-2">
+            This document is subject to BCP 78 and the IETF Trust's Legal
+            Provisions Relating to IETF Documents
+            (<span><a href="https://trustee.ietf.org/license-info">https://trustee.ietf.org/license-info</a></span>) in effect on the date of
+            publication of this document. Please review these documents
+            carefully, as they describe your rights and restrictions with
+            respect to this document. Code Components extracted from this
+            document must include Simplified BSD License text as described in
+            Section 4.e of the Trust Legal Provisions and are provided without
+            warranty as described in the Simplified BSD License.<a href="#section-boilerplate.2-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="toc">
+<section id="section-toc.1">
+        <a href="#" onclick="scroll(0,0)" class="toplink">▲</a><h2 id="name-table-of-contents">
+<a href="#name-table-of-contents" class="section-name selfRef">Table of Contents</a>
+        </h2>
+<nav class="toc"><ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.1">
+            <p id="section-toc.1-1.1.1"><a href="#section-1" class="xref">1</a>.  <a href="#name-introduction" class="xref">Introduction</a><a href="#section-toc.1-1.1.1" class="pilcrow">¶</a></p>
+<ul class="toc ulEmpty">
+<li class="toc ulEmpty" id="section-toc.1-1.1.2.1">
+                <p id="section-toc.1-1.1.2.1.1"><a href="#section-1.1" class="xref">1.1</a>.  <a href="#name-terminology" class="xref">Terminology</a><a href="#section-toc.1-1.1.2.1.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.2">
+            <p id="section-toc.1-1.2.1"><a href="#section-2" class="xref">2</a>.  <a href="#name-deprecating-md-mf-mb-mg-mr-" class="xref">Deprecating MD, MF, MB, MG, MR, MINFO, MAILA, and MAILB RR Types</a><a href="#section-toc.1-1.2.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.3">
+            <p id="section-toc.1-1.3.1"><a href="#section-3" class="xref">3</a>.  <a href="#name-iana-considerations" class="xref">IANA Considerations</a><a href="#section-toc.1-1.3.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.4">
+            <p id="section-toc.1-1.4.1"><a href="#section-4" class="xref">4</a>.  <a href="#name-implementation-consideratio" class="xref">Implementation Considerations</a><a href="#section-toc.1-1.4.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.5">
+            <p id="section-toc.1-1.5.1"><a href="#section-5" class="xref">5</a>.  <a href="#name-security-considerations" class="xref">Security Considerations</a><a href="#section-toc.1-1.5.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.6">
+            <p id="section-toc.1-1.6.1"><a href="#section-6" class="xref">6</a>.  <a href="#name-operational-considerations" class="xref">Operational Considerations</a><a href="#section-toc.1-1.6.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.7">
+            <p id="section-toc.1-1.7.1"><a href="#section-7" class="xref">7</a>.  <a href="#name-acknowledgments" class="xref">Acknowledgments</a><a href="#section-toc.1-1.7.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.8">
+            <p id="section-toc.1-1.8.1"><a href="#section-8" class="xref">8</a>.  <a href="#name-normative-references" class="xref">Normative References</a><a href="#section-toc.1-1.8.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.9">
+            <p id="section-toc.1-1.9.1"><a href="#section-9" class="xref">9</a>.  <a href="#name-informative-references" class="xref">Informative References</a><a href="#section-toc.1-1.9.1" class="pilcrow">¶</a></p>
+</li>
+<li class="toc ulEmpty" id="section-toc.1-1.10">
+            <p id="section-toc.1-1.10.1"><a href="#section-appendix.a" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a><a href="#section-toc.1-1.10.1" class="pilcrow">¶</a></p>
+</li>
+</ul>
+</nav>
+</section>
+</div>
+<div id="introduction">
+<section id="section-1">
+      <h2 id="name-introduction">
+<a href="#section-1" class="section-number selfRef">1. </a><a href="#name-introduction" class="section-name selfRef">Introduction</a>
+      </h2>
+<p id="section-1-1"><span>[<a href="#RFC1035" class="xref">RFC1035</a>]</span> and other documents have defined some
+Resource Record (RR) Types that are no longer in common use,
+some of which have been rendered obsolete by subsequent standards,
+but have never been clearly deprecated in the context of the DNS.
+In some cases there have been interoperability problems between
+DNS implementations that support these types and those that do
+not - for example, because of DNS name compression in the
+wire format. Continued support for these RR Types imposes a
+complexity cost on new implementations for little benefit.<a href="#section-1-1" class="pilcrow">¶</a></p>
+<p id="section-1-2">This document formally deprecates such RR Types, allowing
+implementations to drop specific support for them.<a href="#section-1-2" class="pilcrow">¶</a></p>
+<div id="terminology">
+<section id="section-1.1">
+        <h3 id="name-terminology">
+<a href="#section-1.1" class="section-number selfRef">1.1. </a><a href="#name-terminology" class="section-name selfRef">Terminology</a>
+        </h3>
+<p id="section-1.1-1">The key words <span class="bcp14">MUST</span>, <span class="bcp14">MUST NOT</span>, <span class="bcp14">REQUIRED</span>, <span class="bcp14">SHALL</span>,
+<span class="bcp14">SHALL NOT</span>, <span class="bcp14">SHOULD</span>, <span class="bcp14">SHOULD NOT</span>, <span class="bcp14">RECOMMENDED</span>, <span class="bcp14">MAY</span>,
+and <span class="bcp14">OPTIONAL</span> in this document are to be interpreted as described in
+<span>[<a href="#RFC2119" class="xref">RFC2119</a>]</span>.<a href="#section-1.1-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+</div>
+<div id="deprecating-md-mf-mb-mg-mr-minfo-maila-and-mailb-rr-types">
+<section id="section-2">
+      <h2 id="name-deprecating-md-mf-mb-mg-mr-">
+<a href="#section-2" class="section-number selfRef">2. </a><a href="#name-deprecating-md-mf-mb-mg-mr-" class="section-name selfRef">Deprecating MD, MF, MB, MG, MR, MINFO, MAILA, and MAILB RR Types</a>
+      </h2>
+<p id="section-2-1">The MD, MF, MB, MG, MR, MINFO, MAILA, and MAILB RR Types aren't used in any
+existing standards, and this documents deprecates their usage.  The MD, MF,
+MB, MG, MR, and MINFO RR Types RDATA contain a domain name that could be
+compressed in the RDATA section.<a href="#section-2-1" class="pilcrow">¶</a></p>
+<p id="section-2-2">As an update to <span>[<a href="#RFC3597" class="xref">RFC3597</a>]</span> and <span>[<a href="#RFC4034" class="xref">RFC4034</a>]</span> this document specifies that
+for MD, MF, MB, MG, MR, and MINFO RR types, the canonical form is such that
+no downcasing of embedded domain names takes place, and is otherwise
+identical to the canonical form specified in <a href="https://rfc-editor.org/rfc/rfc4034" class="relref">6.2</a>.<a href="#section-2-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="iana">
+<section id="section-3">
+      <h2 id="name-iana-considerations">
+<a href="#section-3" class="section-number selfRef">3. </a><a href="#name-iana-considerations" class="section-name selfRef">IANA Considerations</a>
+      </h2>
+<p id="section-3-1">This document updates the IANA registry "Domain Name System (DNS)
+Parameters" (<span>[<a href="#DNS-IANA" class="xref">DNS-IANA</a>]</span>) as follows:<a href="#section-3-1" class="pilcrow">¶</a></p>
+<span id="name-updates-to-dns-rr-types"></span><table class="center" id="table-1">
+        <caption>
+<a href="#table-1" class="selfRef">Table 1</a>:
+<a href="#name-updates-to-dns-rr-types" class="selfRef">Updates to DNS RR Types</a>
+        </caption>
+<thead>
+          <tr>
+            <th class="text-left" rowspan="1" colspan="1">TYPE</th>
+            <th class="text-left" rowspan="1" colspan="1">Value</th>
+            <th class="text-left" rowspan="1" colspan="1">Meaning</th>
+            <th class="text-left" rowspan="1" colspan="1">Reference</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="text-left" rowspan="1" colspan="1">MD</td>
+            <td class="text-left" rowspan="1" colspan="1">3</td>
+            <td class="text-left" rowspan="1" colspan="1">DEPRECATED</td>
+            <td class="text-left" rowspan="1" colspan="1">This document</td>
+          </tr>
+          <tr>
+            <td class="text-left" rowspan="1" colspan="1">MF</td>
+            <td class="text-left" rowspan="1" colspan="1">4</td>
+            <td class="text-left" rowspan="1" colspan="1">DEPRECATED</td>
+            <td class="text-left" rowspan="1" colspan="1">This document</td>
+          </tr>
+          <tr>
+            <td class="text-left" rowspan="1" colspan="1">MB</td>
+            <td class="text-left" rowspan="1" colspan="1">7</td>
+            <td class="text-left" rowspan="1" colspan="1">DEPRECATED</td>
+            <td class="text-left" rowspan="1" colspan="1">This document</td>
+          </tr>
+          <tr>
+            <td class="text-left" rowspan="1" colspan="1">MG</td>
+            <td class="text-left" rowspan="1" colspan="1">8</td>
+            <td class="text-left" rowspan="1" colspan="1">DEPRECATED</td>
+            <td class="text-left" rowspan="1" colspan="1">This document</td>
+          </tr>
+          <tr>
+            <td class="text-left" rowspan="1" colspan="1">MR</td>
+            <td class="text-left" rowspan="1" colspan="1">9</td>
+            <td class="text-left" rowspan="1" colspan="1">DEPRECATED</td>
+            <td class="text-left" rowspan="1" colspan="1">This document</td>
+          </tr>
+          <tr>
+            <td class="text-left" rowspan="1" colspan="1">MINFO</td>
+            <td class="text-left" rowspan="1" colspan="1">14</td>
+            <td class="text-left" rowspan="1" colspan="1">DEPRECATED</td>
+            <td class="text-left" rowspan="1" colspan="1">This document</td>
+          </tr>
+        </tbody>
+      </table>
+</section>
+</div>
+<div id="implementation">
+<section id="section-4">
+      <h2 id="name-implementation-consideratio">
+<a href="#section-4" class="section-number selfRef">4. </a><a href="#name-implementation-consideratio" class="section-name selfRef">Implementation Considerations</a>
+      </h2>
+<p id="section-4-1">Obsolete types will be flagged as DEPRECATED in the IANA registry, and the
+following guidance is given to DNS implementors in the handling of these RR
+types:<a href="#section-4-1" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="section-4-2">
+        <li id="section-4-2.1">
+          <p id="section-4-2.1.1">Authoritative DNS Servers SHOULD issue a warning when loading zones that
+contain DEPRECATED RR Types;<a href="#section-4-2.1.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-4-2.2">
+          <p id="section-4-2.2.1">DNS Servers MUST NOT compress RDATA when rendering DEPRECATED RR Types
+to wire format;<a href="#section-4-2.2.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-4-2.3">
+          <p id="section-4-2.3.1">Recursive DNS Servers MAY support legacy compression in DEPRECATED RR
+Types for received data for backward compatibility if desired, but
+SHOULD warn if such information is received.  Compressed RDATA in
+DEPRECATED RR Types MUST be uncompressed before sending and they MUST
+NOT be re-transmitted;<a href="#section-4-2.3.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-4-2.4">
+          <p id="section-4-2.4.1">DNS Clients which receive DEPRECATED RR Types MAY interpret them as
+unknown RR types (<span>[<a href="#RFC3597" class="xref">RFC3597</a>]</span>), and MUST NOT interfere with
+their transmission;<a href="#section-4-2.4.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-4-2.5">
+          <p id="section-4-2.5.1">DNSSEC Validators and Signers SHOULD treat RDATA for DEPRECATED RR Types
+as opaque with respect to canonical RR ordering and deduplication;<a href="#section-4-2.5.1" class="pilcrow">¶</a></p>
+</li>
+<li id="section-4-2.6">
+          <p id="section-4-2.6.1">DEPRECATED RR Types MUST NOT be treated as a known type with respect to
+the wire protocol.<a href="#section-4-2.6.1" class="pilcrow">¶</a></p>
+</li>
+</ol>
+</section>
+</div>
+<div id="security">
+<section id="section-5">
+      <h2 id="name-security-considerations">
+<a href="#section-5" class="section-number selfRef">5. </a><a href="#name-security-considerations" class="section-name selfRef">Security Considerations</a>
+      </h2>
+<p id="section-5-1">This document has no security considerations.<a href="#section-5-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="operation">
+<section id="section-6">
+      <h2 id="name-operational-considerations">
+<a href="#section-6" class="section-number selfRef">6. </a><a href="#name-operational-considerations" class="section-name selfRef">Operational Considerations</a>
+      </h2>
+<p id="section-6-1">The varying states of implementation of MD, MF, MB, MG, MR, and MINFO RR
+Types have already caused operational problems between DNS implementations
+that do implement the aforementioned types and those that don't, because of
+mismatched handling of DNS compression on the wire.  This document aims to
+rectify the situation by encouraging removal of support for all these RR
+types in all DNS implementations.  This should not cause signficant
+operational problems because these records are not in wide use on the
+Internet. [COMMENT: Some data?]<a href="#section-6-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="ack">
+<section id="section-7">
+      <h2 id="name-acknowledgments">
+<a href="#section-7" class="section-number selfRef">7. </a><a href="#name-acknowledgments" class="section-name selfRef">Acknowledgments</a>
+      </h2>
+<p id="section-7-1">The authors would like to thank Peter van Dijk for prompting us to write
+the draft, Daniel Salzman for reviewing the document, and Michael
+Casadevall for contributions to the Implementation Considerations section.<a href="#section-7-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<section id="section-8">
+      <h2 id="name-normative-references">
+<a href="#section-8" class="section-number selfRef">8. </a><a href="#name-normative-references" class="section-name selfRef">Normative References</a>
+      </h2>
+<dl class="references">
+<dt id="RFC1034">[RFC1034]</dt>
+<dd>
+<span class="refAuthor">Mockapetris, P.</span>, <span class="refTitle">"Domain names - concepts and facilities"</span>, <span class="seriesInfo">STD 13</span>, <span class="seriesInfo">RFC 1034</span>, <span class="seriesInfo">DOI 10.17487/RFC1034</span>, <time datetime="1987-11">November 1987</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc1034">https://www.rfc-editor.org/info/rfc1034</a>&gt;</span>. </dd>
+<dt id="RFC1035">[RFC1035]</dt>
+<dd>
+<span class="refAuthor">Mockapetris, P.</span>, <span class="refTitle">"Domain names - implementation and specification"</span>, <span class="seriesInfo">STD 13</span>, <span class="seriesInfo">RFC 1035</span>, <span class="seriesInfo">DOI 10.17487/RFC1035</span>, <time datetime="1987-11">November 1987</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc1035">https://www.rfc-editor.org/info/rfc1035</a>&gt;</span>. </dd>
+<dt id="RFC2119">[RFC2119]</dt>
+<dd>
+<span class="refAuthor">Bradner, S.</span>, <span class="refTitle">"Key words for use in RFCs to Indicate Requirement Levels"</span>, <span class="seriesInfo">BCP 14</span>, <span class="seriesInfo">RFC 2119</span>, <span class="seriesInfo">DOI 10.17487/RFC2119</span>, <time datetime="1997-03">March 1997</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc2119">https://www.rfc-editor.org/info/rfc2119</a>&gt;</span>. </dd>
+<dt id="RFC3597">[RFC3597]</dt>
+<dd>
+<span class="refAuthor">Gustafsson, A.</span>, <span class="refTitle">"Handling of Unknown DNS Resource Record (RR) Types"</span>, <span class="seriesInfo">RFC 3597</span>, <span class="seriesInfo">DOI 10.17487/RFC3597</span>, <time datetime="2003-09">September 2003</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc3597">https://www.rfc-editor.org/info/rfc3597</a>&gt;</span>. </dd>
+<dt id="RFC4034">[RFC4034]</dt>
+<dd>
+<span class="refAuthor">Arends, R.</span><span class="refAuthor">, Austein, R.</span><span class="refAuthor">, Larson, M.</span><span class="refAuthor">, Massey, D.</span><span class="refAuthor">, and S. Rose</span>, <span class="refTitle">"Resource Records for the DNS Security Extensions"</span>, <span class="seriesInfo">RFC 4034</span>, <span class="seriesInfo">DOI 10.17487/RFC4034</span>, <time datetime="2005-03">March 2005</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc4034">https://www.rfc-editor.org/info/rfc4034</a>&gt;</span>. </dd>
+</dl>
+</section>
+<section id="section-9">
+      <h2 id="name-informative-references">
+<a href="#section-9" class="section-number selfRef">9. </a><a href="#name-informative-references" class="section-name selfRef">Informative References</a>
+      </h2>
+<dl class="references">
+<dt id="DNS-IANA">[DNS-IANA]</dt>
+<dd>
+<span class="refTitle">"Domain Name System (DNS) Parameters"</span>, <time></time>, <span>&lt;<a href="https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml">https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml</a>&gt;</span>. </dd>
+</dl>
+</section>
+<div id="authors-addresses">
+<section id="section-appendix.a">
+      <h2 id="name-authors-addresses">
+<a href="#name-authors-addresses" class="section-name selfRef">Authors' Addresses</a>
+      </h2>
+<address class="vcard">
+        <div dir="auto" class="left"><span class="fn nameRole">Ondřej Surý</span></div>
+<div dir="auto" class="left"><span class="org">ISC</span></div>
+<div dir="auto" class="left"><span class="street-address">53 Main St.</span></div>
+<div dir="auto" class="left">
+<span class="locality">Newmarket</span>, <span class="region">NH</span> <span class="postal-code">03824</span>
+</div>
+<div dir="auto" class="left"><span class="country-name">United States of America</span></div>
+<div class="email">
+<span>Email:</span>
+<a href="mailto:ondrej@isc.org" class="email">ondrej@isc.org</a>
+</div>
+</address>
+<address class="vcard">
+        <div dir="auto" class="left"><span class="fn nameRole">Evan Hunt</span></div>
+<div dir="auto" class="left"><span class="org">ISC</span></div>
+<div dir="auto" class="left"><span class="street-address">53 Main St.</span></div>
+<div dir="auto" class="left">
+<span class="locality">Newmarket</span>, <span class="region">NH</span> <span class="postal-code">03824</span>
+</div>
+<div dir="auto" class="left"><span class="country-name">United States of America</span></div>
+<div class="email">
+<span>Email:</span>
+<a href="mailto:each@isc.org" class="email">each@isc.org</a>
+</div>
+</address>
+</section>
+</div>
+<script>var toc = document.getElementById("toc");
+var tocToggle = toc.querySelector("h2");
+var tocNav = toc.querySelector("nav");
+
+// mobile menu toggle
+tocToggle.onclick = function(event) {
+    if (window.innerWidth < 1024) {
+ var tocNavDisplay = tocNav.currentStyle ? tocNav.currentStyle.display : getComputedStyle(tocNav, null).display;
+ if (tocNavDisplay == "none") {
+     tocNav.style.display = "block";
+ } else {
+     tocNav.style.display = "none";
+ }
+    }
+}
+
+// toc anchor scroll to anchor
+tocNav.addEventListener("click", function (event) {
+    event.preventDefault();
+    if (event.target.nodeName == 'A') {
+ if (window.innerWidth < 1024) {
+     tocNav.style.display = "none";
+ }
+ var href = event.target.getAttribute("href");
+ var anchorId = href.substr(1);
+ var anchor =  document.getElementById(anchorId);
+ anchor.scrollIntoView(true);
+ window.history.pushState("","",href);
+    }
+});
+
+// switch toc mode when window resized
+window.onresize = function () {
+    if (window.innerWidth < 1024) {
+ tocNav.style.display = "none";
+    } else {
+ tocNav.style.display = "block";
+    }
+}
+</script>
+</body>
+</html>

--- a/draft-sury-dnsop-deprecate-obsolete-resource-records.html
+++ b/draft-sury-dnsop-deprecate-obsolete-resource-records.html
@@ -9,9 +9,10 @@
 <meta content="Evan Hunt" name="author">
 <meta content="
        This document deprecates Resource Record (RR) Types that are
-either no longer being used for anything meaningful or have
-been made obsolete by other RFCs.  This document updates
- ,  ,  , and  . 
+either no longer being used in any meaningful way the DNS, or
+have already been rendered obsolete by other RFCs.  This
+document updates  ,  ,  , and
+ . 
     " name="description">
 <meta content="xml2rfc 2.40.0" name="generator">
 <meta content="DNS" name="keyword">
@@ -1059,11 +1060,11 @@ ol.type-I { list-style-type: lower-roman; }
 <thead><tr>
 <td class="left">Internet-Draft</td>
 <td class="center">Deprecating RRTYPEs</td>
-<td class="right">April 2021</td>
+<td class="right">September 2022</td>
 </tr></thead>
 <tfoot><tr>
 <td class="left">Sury &amp; Hunt</td>
-<td class="center">Expires 16 October 2021</td>
+<td class="center">Expires 23 March 2023</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -1079,12 +1080,12 @@ ol.type-I { list-style-type: lower-roman; }
 <a href="https://www.rfc-editor.org/rfc/rfc1034" class="eref">1034</a>, <a href="https://www.rfc-editor.org/rfc/rfc1035" class="eref">1035</a>, <a href="https://www.rfc-editor.org/rfc/rfc3597" class="eref">3597</a>, <a href="https://www.rfc-editor.org/rfc/rfc4034" class="eref">4034</a> (if approved)</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2021-04-14" class="published">14 April 2021</time>
+<time datetime="2022-09-19" class="published">19 September 2022</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Standards Track</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2021-10-16">16 October 2021</time></dd>
+<dd class="expires"><time datetime="2023-03-23">23 March 2023</time></dd>
 <dt class="label-authors">Authors:</dt>
 <dd class="authors">
 <div class="author">
@@ -1102,9 +1103,10 @@ ol.type-I { list-style-type: lower-roman; }
 <section id="section-abstract">
       <h2 id="abstract"><a href="#abstract" class="selfRef">Abstract</a></h2>
 <p id="section-abstract-1">This document deprecates Resource Record (RR) Types that are
-either no longer being used for anything meaningful or have
-been made obsolete by other RFCs.  This document updates
-<span>[<a href="#RFC1034" class="xref">RFC1034</a>]</span>, <span>[<a href="#RFC1035" class="xref">RFC1035</a>]</span>, <span>[<a href="#RFC3597" class="xref">RFC3597</a>]</span>, and <span>[<a href="#RFC4034" class="xref">RFC4034</a>]</span>.<a href="#section-abstract-1" class="pilcrow">¶</a></p>
+either no longer being used in any meaningful way the DNS, or
+have already been rendered obsolete by other RFCs.  This
+document updates <span>[<a href="#RFC1034" class="xref">RFC1034</a>]</span>, <span>[<a href="#RFC1035" class="xref">RFC1035</a>]</span>, <span>[<a href="#RFC3597" class="xref">RFC3597</a>]</span>, and
+<span>[<a href="#RFC4034" class="xref">RFC4034</a>]</span>.<a href="#section-abstract-1" class="pilcrow">¶</a></p>
 </section>
 <div id="status-of-memo">
 <section id="section-boilerplate.1">
@@ -1125,7 +1127,7 @@ been made obsolete by other RFCs.  This document updates
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on 16 October 2021.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on 23 March 2023.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">
@@ -1134,7 +1136,7 @@ been made obsolete by other RFCs.  This document updates
 <a href="#name-copyright-notice" class="section-name selfRef">Copyright Notice</a>
         </h2>
 <p id="section-boilerplate.2-1">
-            Copyright (c) 2021 IETF Trust and the persons identified as the
+            Copyright (c) 2022 IETF Trust and the persons identified as the
             document authors. All rights reserved.<a href="#section-boilerplate.2-1" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.2-2">
             This document is subject to BCP 78 and the IETF Trust's Legal
@@ -1199,14 +1201,13 @@ been made obsolete by other RFCs.  This document updates
 <a href="#section-1" class="section-number selfRef">1. </a><a href="#name-introduction" class="section-name selfRef">Introduction</a>
       </h2>
 <p id="section-1-1"><span>[<a href="#RFC1035" class="xref">RFC1035</a>]</span> and other documents have defined some
-Resource Record (RR) Types that are no longer in common use,
-some of which have been rendered obsolete by subsequent standards,
-but have never been clearly deprecated in the context of the DNS.
-In some cases there have been interoperability problems between
-DNS implementations that support these types and those that do
-not - for example, because of DNS name compression in the
-wire format. Continued support for these RR Types imposes a
-complexity cost on new implementations for little benefit.<a href="#section-1-1" class="pilcrow">¶</a></p>
+Resource Record (RR) Types that are no longer in common use.
+Some of these have been rendered obsolete by subsequent standards,
+but were never clearly deprecated.  In some cases there have been
+interoperability problems between DNS implementations that supported
+these types and those that did not: for example, because of DNS name
+compression in the wire format. Continued support for these RR Types
+imposes a complexity cost on new implementations for little benefit.<a href="#section-1-1" class="pilcrow">¶</a></p>
 <p id="section-1-2">This document formally deprecates such RR Types, allowing
 implementations to drop specific support for them.<a href="#section-1-2" class="pilcrow">¶</a></p>
 <div id="terminology">
@@ -1227,14 +1228,15 @@ and <span class="bcp14">OPTIONAL</span> in this document are to be interpreted a
       <h2 id="name-deprecating-md-mf-mb-mg-mr-">
 <a href="#section-2" class="section-number selfRef">2. </a><a href="#name-deprecating-md-mf-mb-mg-mr-" class="section-name selfRef">Deprecating MD, MF, MB, MG, MR, MINFO, MAILA, and MAILB RR Types</a>
       </h2>
-<p id="section-2-1">The MD, MF, MB, MG, MR, MINFO, MAILA, and MAILB RR Types aren't used in any
-existing standards, and this documents deprecates their usage.  The MD, MF,
-MB, MG, MR, and MINFO RR Types RDATA contain a domain name that could be
-compressed in the RDATA section.<a href="#section-2-1" class="pilcrow">¶</a></p>
-<p id="section-2-2">As an update to <span>[<a href="#RFC3597" class="xref">RFC3597</a>]</span> and <span>[<a href="#RFC4034" class="xref">RFC4034</a>]</span> this document specifies that
-for MD, MF, MB, MG, MR, and MINFO RR types, the canonical form is such that
-no downcasing of embedded domain names takes place, and is otherwise
-identical to the canonical form specified in <a href="https://rfc-editor.org/rfc/rfc4034" class="relref">6.2</a>.<a href="#section-2-2" class="pilcrow">¶</a></p>
+<p id="section-2-1">The MD, MF, MB, MG, MR, MINFO, MAILA, and MAILB RR Types are not used in
+any existing standards.  This document deprecates their usage.<a href="#section-2-1" class="pilcrow">¶</a></p>
+<p id="section-2-2">The MD, MF, MB, MG, MR, and MINFO RR Types contain domain names in their
+RDATA. DNS compression MUST NOT be applied to these domain names when
+sending.<a href="#section-2-2" class="pilcrow">¶</a></p>
+<p id="section-2-3">As an update to <span>[<a href="#RFC3597" class="xref">RFC3597</a>]</span> and <span>[<a href="#RFC4034" class="xref">RFC4034</a>]</span> this document specifies that
+for MD, MF, MB, MG, MR, and MINFO RR types, the canonical form such that
+they do NOT include downcasing of embedded domain names.  Canonical forms
+otherwise remain as specified in <span><a href="https://rfc-editor.org/rfc/rfc4034" class="relref">Section 6.2</a> of [<a href="#RFC4034" class="xref">RFC4034</a>]</span>.<a href="#section-2-3" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="iana">
@@ -1294,6 +1296,18 @@ Parameters" (<span>[<a href="#DNS-IANA" class="xref">DNS-IANA</a>]</span>) as fo
             <td class="text-left" rowspan="1" colspan="1">DEPRECATED</td>
             <td class="text-left" rowspan="1" colspan="1">This document</td>
           </tr>
+          <tr>
+            <td class="text-left" rowspan="1" colspan="1">MAILB</td>
+            <td class="text-left" rowspan="1" colspan="1">253</td>
+            <td class="text-left" rowspan="1" colspan="1">DEPRECATED</td>
+            <td class="text-left" rowspan="1" colspan="1">This document</td>
+          </tr>
+          <tr>
+            <td class="text-left" rowspan="1" colspan="1">MAILA</td>
+            <td class="text-left" rowspan="1" colspan="1">254</td>
+            <td class="text-left" rowspan="1" colspan="1">DEPRECATED</td>
+            <td class="text-left" rowspan="1" colspan="1">This document</td>
+          </tr>
         </tbody>
       </table>
 </section>
@@ -1319,21 +1333,17 @@ to wire format;<a href="#section-4-2.2.1" class="pilcrow">¶</a></p>
           <p id="section-4-2.3.1">Recursive DNS Servers MAY support legacy compression in DEPRECATED RR
 Types for received data for backward compatibility if desired, but
 SHOULD warn if such information is received.  Compressed RDATA in
-DEPRECATED RR Types MUST be uncompressed before sending and they MUST
-NOT be re-transmitted;<a href="#section-4-2.3.1" class="pilcrow">¶</a></p>
+DEPRECATED RR Types MUST be uncompressed before sending, and MUST
+NOT be re-transmitted in compressed form;<a href="#section-4-2.3.1" class="pilcrow">¶</a></p>
 </li>
 <li id="section-4-2.4">
           <p id="section-4-2.4.1">DNS Clients which receive DEPRECATED RR Types MAY interpret them as
-unknown RR types (<span>[<a href="#RFC3597" class="xref">RFC3597</a>]</span>), and MUST NOT interfere with
+unknown RR Types (<span>[<a href="#RFC3597" class="xref">RFC3597</a>]</span>), and MUST NOT interfere with
 their transmission;<a href="#section-4-2.4.1" class="pilcrow">¶</a></p>
 </li>
 <li id="section-4-2.5">
           <p id="section-4-2.5.1">DNSSEC Validators and Signers SHOULD treat RDATA for DEPRECATED RR Types
 as opaque with respect to canonical RR ordering and deduplication;<a href="#section-4-2.5.1" class="pilcrow">¶</a></p>
-</li>
-<li id="section-4-2.6">
-          <p id="section-4-2.6.1">DEPRECATED RR Types MUST NOT be treated as a known type with respect to
-the wire protocol.<a href="#section-4-2.6.1" class="pilcrow">¶</a></p>
 </li>
 </ol>
 </section>
@@ -1351,14 +1361,13 @@ the wire protocol.<a href="#section-4-2.6.1" class="pilcrow">¶</a></p>
       <h2 id="name-operational-considerations">
 <a href="#section-6" class="section-number selfRef">6. </a><a href="#name-operational-considerations" class="section-name selfRef">Operational Considerations</a>
       </h2>
-<p id="section-6-1">The varying states of implementation of MD, MF, MB, MG, MR, and MINFO RR
+<p id="section-6-1">Varying states of implementation of MD, MF, MB, MG, MR, and MINFO RR
 Types have already caused operational problems between DNS implementations
-that do implement the aforementioned types and those that don't, because of
-mismatched handling of DNS compression on the wire.  This document aims to
-rectify the situation by encouraging removal of support for all these RR
-types in all DNS implementations.  This should not cause signficant
-operational problems because these records are not in wide use on the
-Internet. [COMMENT: Some data?]<a href="#section-6-1" class="pilcrow">¶</a></p>
+that did, and did not, implement them, as a result of different behavior
+with resepect to DNS compression on the wire. This document aims to rectify
+the situation by encourating removal of support for all these RR Types in
+DNS implementations. This should cause few if any operational problems,
+because these types are not in common use on the internet.<a href="#section-6-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="ack">
@@ -1367,7 +1376,7 @@ Internet. [COMMENT: Some data?]<a href="#section-6-1" class="pilcrow">¶</a></p>
 <a href="#section-7" class="section-number selfRef">7. </a><a href="#name-acknowledgments" class="section-name selfRef">Acknowledgments</a>
       </h2>
 <p id="section-7-1">The authors would like to thank Peter van Dijk for prompting us to write
-the draft, Daniel Salzman for reviewing the document, and Michael
+this draft, Daniel Salzman for reviewing the document, and Michael
 Casadevall for contributions to the Implementation Considerations section.<a href="#section-7-1" class="pilcrow">¶</a></p>
 </section>
 </div>
@@ -1411,9 +1420,9 @@ Casadevall for contributions to the Implementation Considerations section.<a hre
 <address class="vcard">
         <div dir="auto" class="left"><span class="fn nameRole">Ondřej Surý</span></div>
 <div dir="auto" class="left"><span class="org">ISC</span></div>
-<div dir="auto" class="left"><span class="street-address">53 Main St.</span></div>
+<div dir="auto" class="left"><span class="street-address">PO Box 360</span></div>
 <div dir="auto" class="left">
-<span class="locality">Newmarket</span>, <span class="region">NH</span> <span class="postal-code">03824</span>
+<span class="locality">Newmarket</span>, <span class="region">NH</span> <span class="postal-code">03857</span>
 </div>
 <div dir="auto" class="left"><span class="country-name">United States of America</span></div>
 <div class="email">
@@ -1424,9 +1433,9 @@ Casadevall for contributions to the Implementation Considerations section.<a hre
 <address class="vcard">
         <div dir="auto" class="left"><span class="fn nameRole">Evan Hunt</span></div>
 <div dir="auto" class="left"><span class="org">ISC</span></div>
-<div dir="auto" class="left"><span class="street-address">53 Main St.</span></div>
+<div dir="auto" class="left"><span class="street-address">PO Box 360</span></div>
 <div dir="auto" class="left">
-<span class="locality">Newmarket</span>, <span class="region">NH</span> <span class="postal-code">03824</span>
+<span class="locality">Newmarket</span>, <span class="region">NH</span> <span class="postal-code">03857</span>
 </div>
 <div dir="auto" class="left"><span class="country-name">United States of America</span></div>
 <div class="email">

--- a/draft-sury-dnsop-deprecate-obsolete-resource-records.md
+++ b/draft-sury-dnsop-deprecate-obsolete-resource-records.md
@@ -6,7 +6,7 @@ workgroup		= "DNS Operations"
 area			= "Operations and Management"
 submissiontype	        = "IETF"
 ipr			= "trust200902"
-date			= 2021-04-14T09:00:00Z
+date			= 2022-09-19T09:00:00Z
 keyword			= [ "DNS", "RRTYPE", "RR" ]
 
 [seriesInfo]
@@ -22,10 +22,10 @@ organization	= "ISC"
  [author.address]
  email			= "ondrej@isc.org"
   [author.address.postal]
-  street		= "53 Main St."
+  street		= "PO Box 360"
   city			= "Newmarket"
   region		= "NH"
-  code			= "03824"
+  code			= "03857"
   country		= "USA"
 
 [[author]]
@@ -36,10 +36,10 @@ organization	= "ISC"
  [author.address]
  email			= "each@isc.org"
   [author.address.postal]
-  street		= "53 Main St."
+  street		= "PO Box 360"
   city			= "Newmarket"
   region		= "NH"
-  code			= "03824"
+  code			= "03857"
   country		= "USA"
 
 %%%

--- a/draft-sury-dnsop-deprecate-obsolete-resource-records.md
+++ b/draft-sury-dnsop-deprecate-obsolete-resource-records.md
@@ -1,0 +1,164 @@
+%%%
+title			= "Deprecating Obsolete DNS Resource Record Types"
+abbrev			= "Deprecating RRTYPEs"
+updates                 = [1034,1035,3597,4034]
+workgroup		= "DNS Operations"
+area			= "Operations and Management"
+submissiontype	        = "IETF"
+ipr			= "trust200902"
+date			= 2021-04-14T09:00:00Z
+keyword			= [ "DNS", "RRTYPE", "RR" ]
+
+[seriesInfo]
+name			= "Internet-Draft"
+value			= "draft-sury-dnsop-deprecate-obsolete-resource-records-02"
+status			= "standard"
+
+[[author]]
+initials		= "O."
+surname			= "Sury"
+fullname		= "Ondřej Surý"
+organization	= "ISC"
+ [author.address]
+ email			= "ondrej@isc.org"
+  [author.address.postal]
+  street		= "53 Main St."
+  city			= "Newmarket"
+  region		= "NH"
+  code			= "03824"
+  country		= "USA"
+
+[[author]]
+initials		= "E."
+surname			= "Hunt"
+fullname		= "Evan Hunt"
+organization	= "ISC"
+ [author.address]
+ email			= "each@isc.org"
+  [author.address.postal]
+  street		= "53 Main St."
+  city			= "Newmarket"
+  region		= "NH"
+  code			= "03824"
+  country		= "USA"
+
+%%%
+
+.# Abstract
+
+This document deprecates Resource Record (RR) Types that are
+either no longer being used for anything meaningful or have
+been made obsolete by other RFCs.  This document updates
+[@!RFC1034], [@!RFC1035], [@!RFC3597], and [@!RFC4034].
+
+{mainmatter}
+
+# Introduction
+
+[@!RFC1035] and other documents have defined some
+Resource Record (RR) Types that are no longer in common use,
+some of which have been rendered obsolete by subsequent standards,
+but have never been clearly deprecated in the context of the DNS.
+In some cases there have been interoperability problems between
+DNS implementations that support these types and those that do
+not - for example, because of DNS name compression in the
+wire format. Continued support for these RR Types imposes a
+complexity cost on new implementations for little benefit.
+
+This document formally deprecates such RR Types, allowing
+implementations to drop specific support for them.
+
+## Terminology
+
+The key words **MUST**, **MUST NOT**, **REQUIRED**, **SHALL**,
+**SHALL NOT**, **SHOULD**, **SHOULD NOT**, **RECOMMENDED**, **MAY**,
+and **OPTIONAL** in this document are to be interpreted as described in
+[@!RFC2119].
+
+# Deprecating MD, MF, MB, MG, MR, MINFO, MAILA, and MAILB RR Types
+
+The MD, MF, MB, MG, MR, MINFO, MAILA, and MAILB RR Types aren't used in any
+existing standards, and this documents deprecates their usage.  The MD, MF,
+MB, MG, MR, and MINFO RR Types RDATA contain a domain name that could be
+compressed in the RDATA section.
+
+As an update to [@!RFC3597] and [@!RFC4034] this document specifies that
+for MD, MF, MB, MG, MR, and MINFO RR types, the canonical form is such that
+no downcasing of embedded domain names takes place, and is otherwise
+identical to the canonical form specified in [@!RFC4034, section 6.2].
+
+# IANA Considerations {#iana}
+
+This document updates the IANA registry "Domain Name System (DNS)
+Parameters" ([@DNS-IANA]) as follows:
+	
+TYPE   | Value | Meaning    | Reference
+-------|-------|------------|--------------
+MD     | 3     | DEPRECATED | This document
+MF     | 4     | DEPRECATED | This document
+MB     | 7     | DEPRECATED | This document
+MG     | 8     | DEPRECATED | This document
+MR     | 9     | DEPRECATED | This document
+MINFO  | 14    | DEPRECATED | This document
+Table: Updates to DNS RR Types
+
+# Implementation Considerations {#implementation}
+
+Obsolete types will be flagged as DEPRECATED in the IANA registry, and the
+following guidance is given to DNS implementors in the handling of these RR
+types:
+
+1. Authoritative DNS Servers SHOULD issue a warning when loading zones that
+   contain DEPRECATED RR Types;
+
+1. DNS Servers MUST NOT compress RDATA when rendering DEPRECATED RR Types
+   to wire format;
+
+1. Recursive DNS Servers MAY support legacy compression in DEPRECATED RR
+   Types for received data for backward compatibility if desired, but
+   SHOULD warn if such information is received.  Compressed RDATA in
+   DEPRECATED RR Types MUST be uncompressed before sending and they MUST
+   NOT be re-transmitted;
+    
+1. DNS Clients which receive DEPRECATED RR Types MAY interpret them as
+   unknown RR types ([@!RFC3597]), and MUST NOT interfere with
+   their transmission;
+    
+1. DNSSEC Validators and Signers SHOULD treat RDATA for DEPRECATED RR Types
+   as opaque with respect to canonical RR ordering and deduplication;
+
+1. DEPRECATED RR Types MUST NOT be treated as a known type with respect to
+   the wire protocol.
+    
+# Security Considerations {#security}
+
+This document has no security considerations.
+
+# Operational Considerations {#operation}
+
+The varying states of implementation of MD, MF, MB, MG, MR, and MINFO RR
+Types have already caused operational problems between DNS implementations
+that do implement the aforementioned types and those that don't, because of
+mismatched handling of DNS compression on the wire.  This document aims to
+rectify the situation by encouraging removal of support for all these RR
+types in all DNS implementations.  This should not cause signficant
+operational problems because these records are not in wide use on the
+Internet. [COMMENT: Some data?]
+
+# Acknowledgments {#ack}
+
+The authors would like to thank Peter van Dijk for prompting us to write
+the draft, Daniel Salzman for reviewing the document, and Michael
+Casadevall for contributions to the Implementation Considerations section.
+
+{backmatter}
+
+<reference anchor="DNS-IANA" target="https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml">
+  <front>
+    <title>Domain Name System (DNS) Parameters</title>
+    <author initials="" surname="" fullname="">
+      <organization />
+    </author>
+    <date />
+  </front>
+</reference>

--- a/draft-sury-dnsop-deprecate-obsolete-resource-records.md
+++ b/draft-sury-dnsop-deprecate-obsolete-resource-records.md
@@ -47,23 +47,23 @@ organization	= "ISC"
 .# Abstract
 
 This document deprecates Resource Record (RR) Types that are
-either no longer being used for anything meaningful or have
-been made obsolete by other RFCs.  This document updates
-[@!RFC1034], [@!RFC1035], [@!RFC3597], and [@!RFC4034].
+either no longer being used in any meaningful way the DNS, or
+have already been rendered obsolete by other RFCs.  This
+document updates [@!RFC1034], [@!RFC1035], [@!RFC3597], and
+[@!RFC4034].
 
 {mainmatter}
 
 # Introduction
 
 [@!RFC1035] and other documents have defined some
-Resource Record (RR) Types that are no longer in common use,
-some of which have been rendered obsolete by subsequent standards,
-but have never been clearly deprecated in the context of the DNS.
-In some cases there have been interoperability problems between
-DNS implementations that support these types and those that do
-not - for example, because of DNS name compression in the
-wire format. Continued support for these RR Types imposes a
-complexity cost on new implementations for little benefit.
+Resource Record (RR) Types that are no longer in common use.
+Some of these have been rendered obsolete by subsequent standards,
+but were never clearly deprecated.  In some cases there have been
+interoperability problems between DNS implementations that supported
+these types and those that did not: for example, because of DNS name
+compression in the wire format. Continued support for these RR Types
+imposes a complexity cost on new implementations for little benefit.
 
 This document formally deprecates such RR Types, allowing
 implementations to drop specific support for them.
@@ -77,15 +77,17 @@ and **OPTIONAL** in this document are to be interpreted as described in
 
 # Deprecating MD, MF, MB, MG, MR, MINFO, MAILA, and MAILB RR Types
 
-The MD, MF, MB, MG, MR, MINFO, MAILA, and MAILB RR Types aren't used in any
-existing standards, and this documents deprecates their usage.  The MD, MF,
-MB, MG, MR, and MINFO RR Types RDATA contain a domain name that could be
-compressed in the RDATA section.
+The MD, MF, MB, MG, MR, MINFO, MAILA, and MAILB RR Types are not used in
+any existing standards.  This document deprecates their usage.
+
+The MD, MF, MB, MG, MR, and MINFO RR Types contain domain names in their
+RDATA. DNS compression MUST NOT be applied to these domain names when
+sending.
 
 As an update to [@!RFC3597] and [@!RFC4034] this document specifies that
-for MD, MF, MB, MG, MR, and MINFO RR types, the canonical form is such that
-no downcasing of embedded domain names takes place, and is otherwise
-identical to the canonical form specified in [@!RFC4034, section 6.2].
+for MD, MF, MB, MG, MR, and MINFO RR types, the canonical form such that
+they do NOT include downcasing of embedded domain names.  Canonical forms
+otherwise remain as specified in [@!RFC4034, section 6.2].
 
 # IANA Considerations {#iana}
 
@@ -100,6 +102,8 @@ MB     | 7     | DEPRECATED | This document
 MG     | 8     | DEPRECATED | This document
 MR     | 9     | DEPRECATED | This document
 MINFO  | 14    | DEPRECATED | This document
+MAILB  | 253   | DEPRECATED | This document
+MAILA  | 254   | DEPRECATED | This document
 Table: Updates to DNS RR Types
 
 # Implementation Considerations {#implementation}
@@ -117,38 +121,34 @@ types:
 1. Recursive DNS Servers MAY support legacy compression in DEPRECATED RR
    Types for received data for backward compatibility if desired, but
    SHOULD warn if such information is received.  Compressed RDATA in
-   DEPRECATED RR Types MUST be uncompressed before sending and they MUST
-   NOT be re-transmitted;
+   DEPRECATED RR Types MUST be uncompressed before sending, and MUST
+   NOT be re-transmitted in compressed form;
     
 1. DNS Clients which receive DEPRECATED RR Types MAY interpret them as
-   unknown RR types ([@!RFC3597]), and MUST NOT interfere with
+   unknown RR Types ([@!RFC3597]), and MUST NOT interfere with
    their transmission;
     
 1. DNSSEC Validators and Signers SHOULD treat RDATA for DEPRECATED RR Types
    as opaque with respect to canonical RR ordering and deduplication;
 
-1. DEPRECATED RR Types MUST NOT be treated as a known type with respect to
-   the wire protocol.
-    
 # Security Considerations {#security}
 
 This document has no security considerations.
 
 # Operational Considerations {#operation}
 
-The varying states of implementation of MD, MF, MB, MG, MR, and MINFO RR
+Varying states of implementation of MD, MF, MB, MG, MR, and MINFO RR
 Types have already caused operational problems between DNS implementations
-that do implement the aforementioned types and those that don't, because of
-mismatched handling of DNS compression on the wire.  This document aims to
-rectify the situation by encouraging removal of support for all these RR
-types in all DNS implementations.  This should not cause signficant
-operational problems because these records are not in wide use on the
-Internet. [COMMENT: Some data?]
+that did, and did not, implement them, as a result of different behavior
+with resepect to DNS compression on the wire. This document aims to rectify
+the situation by encourating removal of support for all these RR Types in
+DNS implementations. This should cause few if any operational problems,
+because these types are not in common use on the internet.
 
 # Acknowledgments {#ack}
 
 The authors would like to thank Peter van Dijk for prompting us to write
-the draft, Daniel Salzman for reviewing the document, and Michael
+this draft, Daniel Salzman for reviewing the document, and Michael
 Casadevall for contributions to the Implementation Considerations section.
 
 {backmatter}

--- a/draft-sury-dnsop-deprecate-obsolete-resource-records.txt
+++ b/draft-sury-dnsop-deprecate-obsolete-resource-records.txt
@@ -5,8 +5,8 @@
 DNS Operations                                                   O. Sury
 Internet-Draft                                                   E. Hunt
 Updates: 1034, 1035, 3597, 4034 (if approved)                        ISC
-Intended status: Standards Track                           14 April 2021
-Expires: 16 October 2021
+Intended status: Standards Track                       19 September 2022
+Expires: 23 March 2023
 
 
              Deprecating Obsolete DNS Resource Record Types
@@ -15,9 +15,9 @@ Expires: 16 October 2021
 Abstract
 
    This document deprecates Resource Record (RR) Types that are either
-   no longer being used for anything meaningful or have been made
-   obsolete by other RFCs.  This document updates [RFC1034], [RFC1035],
-   [RFC3597], and [RFC4034].
+   no longer being used in any meaningful way the DNS, or have already
+   been rendered obsolete by other RFCs.  This document updates
+   [RFC1034], [RFC1035], [RFC3597], and [RFC4034].
 
 Status of This Memo
 
@@ -34,11 +34,11 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 16 October 2021.
+   This Internet-Draft will expire on 23 March 2023.
 
 Copyright Notice
 
-   Copyright (c) 2021 IETF Trust and the persons identified as the
+   Copyright (c) 2022 IETF Trust and the persons identified as the
    document authors.  All rights reserved.
 
    This document is subject to BCP 78 and the IETF Trust's Legal
@@ -53,9 +53,9 @@ Copyright Notice
 
 
 
-Sury & Hunt              Expires 16 October 2021                [Page 1]
+Sury & Hunt               Expires 23 March 2023                 [Page 1]
 
-Internet-Draft             Deprecating RRTYPEs                April 2021
+Internet-Draft             Deprecating RRTYPEs            September 2022
 
 
 Table of Contents
@@ -76,14 +76,13 @@ Table of Contents
 1.  Introduction
 
    [RFC1035] and other documents have defined some Resource Record (RR)
-   Types that are no longer in common use, some of which have been
-   rendered obsolete by subsequent standards, but have never been
-   clearly deprecated in the context of the DNS.  In some cases there
-   have been interoperability problems between DNS implementations that
-   support these types and those that do not - for example, because of
-   DNS name compression in the wire format.  Continued support for these
-   RR Types imposes a complexity cost on new implementations for little
-   benefit.
+   Types that are no longer in common use.  Some of these have been
+   rendered obsolete by subsequent standards, but were never clearly
+   deprecated.  In some cases there have been interoperability problems
+   between DNS implementations that supported these types and those that
+   did not: for example, because of DNS name compression in the wire
+   format.  Continued support for these RR Types imposes a complexity
+   cost on new implementations for little benefit.
 
    This document formally deprecates such RR Types, allowing
    implementations to drop specific support for them.
@@ -96,23 +95,27 @@ Table of Contents
 
 2.  Deprecating MD, MF, MB, MG, MR, MINFO, MAILA, and MAILB RR Types
 
-   The MD, MF, MB, MG, MR, MINFO, MAILA, and MAILB RR Types aren't used
-   in any existing standards, and this documents deprecates their usage.
-   The MD, MF, MB, MG, MR, and MINFO RR Types RDATA contain a domain
-   name that could be compressed in the RDATA section.
+   The MD, MF, MB, MG, MR, MINFO, MAILA, and MAILB RR Types are not used
+   in any existing standards.  This document deprecates their usage.
+
+   The MD, MF, MB, MG, MR, and MINFO RR Types contain domain names in
+   their RDATA.  DNS compression MUST NOT be applied to these domain
+   names when sending.
 
    As an update to [RFC3597] and [RFC4034] this document specifies that
-   for MD, MF, MB, MG, MR, and MINFO RR types, the canonical form is
-   such that no downcasing of embedded domain names takes place, and is
-   otherwise identical to the canonical form specified in 6.2.
+   for MD, MF, MB, MG, MR, and MINFO RR types, the canonical form such
+   that they do NOT include downcasing of embedded domain names.
 
 
 
 
-Sury & Hunt              Expires 16 October 2021                [Page 2]
+Sury & Hunt               Expires 23 March 2023                 [Page 2]
 
-Internet-Draft             Deprecating RRTYPEs                April 2021
+Internet-Draft             Deprecating RRTYPEs            September 2022
 
+
+   Canonical forms otherwise remain as specified in Section 6.2 of
+   [RFC4034].
 
 3.  IANA Considerations
 
@@ -134,6 +137,10 @@ Internet-Draft             Deprecating RRTYPEs                April 2021
               +-------+-------+------------+---------------+
               | MINFO | 14    | DEPRECATED | This document |
               +-------+-------+------------+---------------+
+              | MAILB | 253   | DEPRECATED | This document |
+              +-------+-------+------------+---------------+
+              | MAILA | 254   | DEPRECATED | This document |
+              +-------+-------+------------+---------------+
 
                      Table 1: Updates to DNS RR Types
 
@@ -153,25 +160,23 @@ Internet-Draft             Deprecating RRTYPEs                April 2021
        DEPRECATED RR Types for received data for backward compatibility
        if desired, but SHOULD warn if such information is received.
        Compressed RDATA in DEPRECATED RR Types MUST be uncompressed
-       before sending and they MUST NOT be re-transmitted;
+       before sending, and MUST NOT be re-transmitted in compressed
+       form;
+
+
+
+Sury & Hunt               Expires 23 March 2023                 [Page 3]
+
+Internet-Draft             Deprecating RRTYPEs            September 2022
+
 
    4.  DNS Clients which receive DEPRECATED RR Types MAY interpret them
-       as unknown RR types ([RFC3597]), and MUST NOT interfere with
+       as unknown RR Types ([RFC3597]), and MUST NOT interfere with
        their transmission;
 
    5.  DNSSEC Validators and Signers SHOULD treat RDATA for DEPRECATED
        RR Types as opaque with respect to canonical RR ordering and
        deduplication;
-
-
-
-Sury & Hunt              Expires 16 October 2021                [Page 3]
-
-Internet-Draft             Deprecating RRTYPEs                April 2021
-
-
-   6.  DEPRECATED RR Types MUST NOT be treated as a known type with
-       respect to the wire protocol.
 
 5.  Security Considerations
 
@@ -179,19 +184,19 @@ Internet-Draft             Deprecating RRTYPEs                April 2021
 
 6.  Operational Considerations
 
-   The varying states of implementation of MD, MF, MB, MG, MR, and MINFO
-   RR Types have already caused operational problems between DNS
-   implementations that do implement the aforementioned types and those
-   that don't, because of mismatched handling of DNS compression on the
-   wire.  This document aims to rectify the situation by encouraging
-   removal of support for all these RR types in all DNS implementations.
-   This should not cause signficant operational problems because these
-   records are not in wide use on the Internet.  [COMMENT: Some data?]
+   Varying states of implementation of MD, MF, MB, MG, MR, and MINFO RR
+   Types have already caused operational problems between DNS
+   implementations that did, and did not, implement them, as a result of
+   different behavior with resepect to DNS compression on the wire.
+   This document aims to rectify the situation by encourating removal of
+   support for all these RR Types in DNS implementations.  This should
+   cause few if any operational problems, because these types are not in
+   common use on the internet.
 
 7.  Acknowledgments
 
    The authors would like to thank Peter van Dijk for prompting us to
-   write the draft, Daniel Salzman for reviewing the document, and
+   write this draft, Daniel Salzman for reviewing the document, and
    Michael Casadevall for contributions to the Implementation
    Considerations section.
 
@@ -214,17 +219,17 @@ Internet-Draft             Deprecating RRTYPEs                April 2021
               (RR) Types", RFC 3597, DOI 10.17487/RFC3597, September
               2003, <https://www.rfc-editor.org/info/rfc3597>.
 
+
+
+Sury & Hunt               Expires 23 March 2023                 [Page 4]
+
+Internet-Draft             Deprecating RRTYPEs            September 2022
+
+
    [RFC4034]  Arends, R., Austein, R., Larson, M., Massey, D., and S.
               Rose, "Resource Records for the DNS Security Extensions",
               RFC 4034, DOI 10.17487/RFC4034, March 2005,
               <https://www.rfc-editor.org/info/rfc4034>.
-
-
-
-Sury & Hunt              Expires 16 October 2021                [Page 4]
-
-Internet-Draft             Deprecating RRTYPEs                April 2021
-
 
 9.  Informative References
 
@@ -236,8 +241,8 @@ Authors' Addresses
 
    Ondřej Surý
    ISC
-   53 Main St.
-   Newmarket, NH 03824
+   PO Box 360
+   Newmarket, NH 03857
    United States of America
 
    Email: ondrej@isc.org
@@ -245,8 +250,8 @@ Authors' Addresses
 
    Evan Hunt
    ISC
-   53 Main St.
-   Newmarket, NH 03824
+   PO Box 360
+   Newmarket, NH 03857
    United States of America
 
    Email: each@isc.org
@@ -272,9 +277,4 @@ Authors' Addresses
 
 
 
-
-
-
-
-
-Sury & Hunt              Expires 16 October 2021                [Page 5]
+Sury & Hunt               Expires 23 March 2023                 [Page 5]

--- a/draft-sury-dnsop-deprecate-obsolete-resource-records.txt
+++ b/draft-sury-dnsop-deprecate-obsolete-resource-records.txt
@@ -2,22 +2,22 @@
 
 
 
-dnsop                                                            O. Sury
-Internet-Draft                               Internet Systems Consortium
-Updates: 1035,3597,4035 (if approved)                     March 26, 2018
-Intended status: Standards Track
-Expires: September 27, 2018
+DNS Operations                                                   O. Sury
+Internet-Draft                                                   E. Hunt
+Updates: 1034, 1035, 3597, 4034 (if approved)                        ISC
+Intended status: Standards Track                           14 April 2021
+Expires: 16 October 2021
 
 
-            Deprecating obsolete DNS Resource Records Types
-           draft-sury-deprecate-obsolete-resource-records-00
+             Deprecating Obsolete DNS Resource Record Types
+        draft-sury-dnsop-deprecate-obsolete-resource-records-02
 
 Abstract
 
-   This document deprecates Resource Records (RR) Types that are either
-   not being used for anything meaningful or were been already made
-   obsolete by other RFCs.  This document updates [RFC1035], [RFC1035],
-   [RFC4034].
+   This document deprecates Resource Record (RR) Types that are either
+   no longer being used for anything meaningful or have been made
+   obsolete by other RFCs.  This document updates [RFC1034], [RFC1035],
+   [RFC3597], and [RFC4034].
 
 Status of This Memo
 
@@ -34,102 +34,114 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on September 27, 2018.
+   This Internet-Draft will expire on 16 October 2021.
 
 Copyright Notice
 
-   Copyright (c) 2018 IETF Trust and the persons identified as the
+   Copyright (c) 2021 IETF Trust and the persons identified as the
    document authors.  All rights reserved.
 
    This document is subject to BCP 78 and the IETF Trust's Legal
-   Provisions Relating to IETF Documents
-   (https://trustee.ietf.org/license-info) in effect on the date of
-   publication of this document.  Please review these documents
-   carefully, as they describe your rights and restrictions with respect
-   to this document.  Code Components extracted from this document must
-   include Simplified BSD License text as described in Section 4.e of
-   the Trust Legal Provisions and are provided without warranty as
-   described in the Simplified BSD License.
+   Provisions Relating to IETF Documents (https://trustee.ietf.org/
+   license-info) in effect on the date of publication of this document.
+   Please review these documents carefully, as they describe your rights
+   and restrictions with respect to this document.  Code Components
+   extracted from this document must include Simplified BSD License text
+   as described in Section 4.e of the Trust Legal Provisions and are
+   provided without warranty as described in the Simplified BSD License.
 
 
 
-Sury                   Expires September 27, 2018               [Page 1]
+
+Sury & Hunt              Expires 16 October 2021                [Page 1]
 
-Internet-Draft        Deprecating old mail RRTYPES            March 2018
+Internet-Draft             Deprecating RRTYPEs                April 2021
 
 
 Table of Contents
 
    1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   2
-   2.  Deprecating MD, MF, MB, MG, MR, MINFO, MAILA, and MAILBRR
-       Types . . . . . . . . . . . . . . . . . . . . . . . . . . . .   2
-   3.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   2
+     1.1.  Terminology . . . . . . . . . . . . . . . . . . . . . . .   2
+   2.  Deprecating MD, MF, MB, MG, MR, MINFO, MAILA, and MAILB RR
+           Types . . . . . . . . . . . . . . . . . . . . . . . . . .   2
+   3.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   3
    4.  Implementation Considerations . . . . . . . . . . . . . . . .   3
-   5.  Security Considerations . . . . . . . . . . . . . . . . . . .   3
+   5.  Security Considerations . . . . . . . . . . . . . . . . . . .   4
    6.  Operational Considerations  . . . . . . . . . . . . . . . . .   4
-   7.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .   4
-   8.  References  . . . . . . . . . . . . . . . . . . . . . . . . .   4
-     8.1.  Normative References  . . . . . . . . . . . . . . . . . .   4
-     8.2.  Informative References  . . . . . . . . . . . . . . . . .   4
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .   4
+   7.  Acknowledgments . . . . . . . . . . . . . . . . . . . . . . .   4
+   8.  Normative References  . . . . . . . . . . . . . . . . . . . .   4
+   9.  Informative References  . . . . . . . . . . . . . . . . . . .   5
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .   5
 
 1.  Introduction
 
-   The [RFC1035] defines couple of old Resource Record (RR) Types that
-   are not being used, and they are not in use and should have been
-   obsoleted years ago.  Some of these RR Types are even causing
-   operational problems between implementations that support them and
-   that don't supported them due DNS compression on the wire, or .  This
-   document deprecates such records to allow the implementations to drop
-   the specific support for such records.
+   [RFC1035] and other documents have defined some Resource Record (RR)
+   Types that are no longer in common use, some of which have been
+   rendered obsolete by subsequent standards, but have never been
+   clearly deprecated in the context of the DNS.  In some cases there
+   have been interoperability problems between DNS implementations that
+   support these types and those that do not - for example, because of
+   DNS name compression in the wire format.  Continued support for these
+   RR Types imposes a complexity cost on new implementations for little
+   benefit.
 
-2.  Deprecating MD, MF, MB, MG, MR, MINFO, MAILA, and MAILBRR Types
+   This document formally deprecates such RR Types, allowing
+   implementations to drop specific support for them.
+
+1.1.  Terminology
+
+   The key words MUST, MUST NOT, REQUIRED, SHALL, SHALL NOT, SHOULD,
+   SHOULD NOT, RECOMMENDED, MAY, and OPTIONAL in this document are to be
+   interpreted as described in [RFC2119].
+
+2.  Deprecating MD, MF, MB, MG, MR, MINFO, MAILA, and MAILB RR Types
 
    The MD, MF, MB, MG, MR, MINFO, MAILA, and MAILB RR Types aren't used
-   in any existing standards, and this documents deprecates the usage.
+   in any existing standards, and this documents deprecates their usage.
    The MD, MF, MB, MG, MR, and MINFO RR Types RDATA contain a domain
    name that could be compressed in the RDATA section.
 
    As an update to [RFC3597] and [RFC4034] this document specifies that
    for MD, MF, MB, MG, MR, and MINFO RR types, the canonical form is
-   such that no downcasing of embedded domain names takes place, and
-   otherwise identical to the canonical form specified in [RFC4034]
-   section 6.2.
+   such that no downcasing of embedded domain names takes place, and is
+   otherwise identical to the canonical form specified in 6.2.
+
+
+
+
+Sury & Hunt              Expires 16 October 2021                [Page 2]
+
+Internet-Draft             Deprecating RRTYPEs                April 2021
+
 
 3.  IANA Considerations
 
-   This documents updates the IANA registry "Domain Name System (DNS)
-   Parameters" ([DNS-IANA]).
-
-
-
-
-
-
-
-
-
-Sury                   Expires September 27, 2018               [Page 2]
-
-Internet-Draft        Deprecating old mail RRTYPES            March 2018
-
+   This document updates the IANA registry "Domain Name System (DNS)
+   Parameters" ([DNS-IANA]) as follows:
 
               +-------+-------+------------+---------------+
               | TYPE  | Value | Meaning    | Reference     |
-              +-------+-------+------------+---------------+
+              +=======+=======+============+===============+
               | MD    | 3     | DEPRECATED | This document |
+              +-------+-------+------------+---------------+
               | MF    | 4     | DEPRECATED | This document |
+              +-------+-------+------------+---------------+
               | MB    | 7     | DEPRECATED | This document |
+              +-------+-------+------------+---------------+
               | MG    | 8     | DEPRECATED | This document |
+              +-------+-------+------------+---------------+
               | MR    | 9     | DEPRECATED | This document |
+              +-------+-------+------------+---------------+
               | MINFO | 14    | DEPRECATED | This document |
               +-------+-------+------------+---------------+
 
+                     Table 1: Updates to DNS RR Types
+
 4.  Implementation Considerations
 
-   Types will be flagged as obsolete/deprecated in the IANA registry,
+   Obsolete types will be flagged as DEPRECATED in the IANA registry,
    and the following guidance is given to DNS implementors in the
-   handling of obsolete/deprecated RR types:
+   handling of these RR types:
 
    1.  Authoritative DNS Servers SHOULD issue a warning when loading
        zones that contain DEPRECATED RR Types;
@@ -151,49 +163,52 @@ Internet-Draft        Deprecating old mail RRTYPES            March 2018
        RR Types as opaque with respect to canonical RR ordering and
        deduplication;
 
-   6.  DEPRECATED RR Types MUST never be treated as a known-type with
+
+
+Sury & Hunt              Expires 16 October 2021                [Page 3]
+
+Internet-Draft             Deprecating RRTYPEs                April 2021
+
+
+   6.  DEPRECATED RR Types MUST NOT be treated as a known type with
        respect to the wire protocol.
 
 5.  Security Considerations
 
-   This document has not security considerations.
-
-
-
-
-
-
-
-
-Sury                   Expires September 27, 2018               [Page 3]
-
-Internet-Draft        Deprecating old mail RRTYPES            March 2018
-
+   This document has no security considerations.
 
 6.  Operational Considerations
 
-   The various state of implementation of MB, MG, MR, MINFO, and WKS
-   records is already causing operational problems between DNS
-   implementations that do implement aforementioned types and those who
-   don't because of the DNS compression on the wire.  This document aims
-   to rectify the situation by removing the support for all these RR
-   types the DNS implementations.  This should not cause any operational
-   problems because the records aren't actually in use on the Internet.
-   [COMMENT: Some data?]
+   The varying states of implementation of MD, MF, MB, MG, MR, and MINFO
+   RR Types have already caused operational problems between DNS
+   implementations that do implement the aforementioned types and those
+   that don't, because of mismatched handling of DNS compression on the
+   wire.  This document aims to rectify the situation by encouraging
+   removal of support for all these RR types in all DNS implementations.
+   This should not cause signficant operational problems because these
+   records are not in wide use on the Internet.  [COMMENT: Some data?]
 
-7.  Acknowledgements
+7.  Acknowledgments
 
-   Peter van Dijk for poking me to write the draft.  Daniel Salzman for
-   reviewing the document.  Evan Hunt and Michael Casadevall to write
-   Implementation Considerations section.
+   The authors would like to thank Peter van Dijk for prompting us to
+   write the draft, Daniel Salzman for reviewing the document, and
+   Michael Casadevall for contributions to the Implementation
+   Considerations section.
 
-8.  References
+8.  Normative References
 
-8.1.  Normative References
+   [RFC1034]  Mockapetris, P., "Domain names - concepts and facilities",
+              STD 13, RFC 1034, DOI 10.17487/RFC1034, November 1987,
+              <https://www.rfc-editor.org/info/rfc1034>.
 
    [RFC1035]  Mockapetris, P., "Domain names - implementation and
               specification", STD 13, RFC 1035, DOI 10.17487/RFC1035,
               November 1987, <https://www.rfc-editor.org/info/rfc1035>.
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119,
+              DOI 10.17487/RFC2119, March 1997,
+              <https://www.rfc-editor.org/info/rfc2119>.
 
    [RFC3597]  Gustafsson, A., "Handling of Unknown DNS Resource Record
               (RR) Types", RFC 3597, DOI 10.17487/RFC3597, September
@@ -204,21 +219,62 @@ Internet-Draft        Deprecating old mail RRTYPES            March 2018
               RFC 4034, DOI 10.17487/RFC4034, March 2005,
               <https://www.rfc-editor.org/info/rfc4034>.
 
-8.2.  Informative References
-
-   [DNS-IANA]
-              "Domain Name System (DNS) Parameters",
-              <https://www.iana.org/assignments/dns-parameters/
-              dns-parameters.xhtml>.
-
-Author's Address
-
-   Ondrej Sury
-   Internet Systems Consortium
-   CZ
-
-   EMail: ondrej@isc.org
 
 
+Sury & Hunt              Expires 16 October 2021                [Page 4]
+
+Internet-Draft             Deprecating RRTYPEs                April 2021
 
-Sury                   Expires September 27, 2018               [Page 4]
+
+9.  Informative References
+
+   [DNS-IANA] "Domain Name System (DNS) Parameters",
+              <https://www.iana.org/assignments/dns-parameters/dns-
+              parameters.xhtml>.
+
+Authors' Addresses
+
+   Ondřej Surý
+   ISC
+   53 Main St.
+   Newmarket, NH 03824
+   United States of America
+
+   Email: ondrej@isc.org
+
+
+   Evan Hunt
+   ISC
+   53 Main St.
+   Newmarket, NH 03824
+   United States of America
+
+   Email: each@isc.org
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Sury & Hunt              Expires 16 October 2021                [Page 5]

--- a/draft-sury-dnsop-deprecate-obsolete-resource-records.xml
+++ b/draft-sury-dnsop-deprecate-obsolete-resource-records.xml
@@ -1,196 +1,204 @@
-<?xml version="1.0"?>
-<?xml-stylesheet type='text/xsl' href='./rfc2629.xslt' ?>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- name="GENERATOR" content="github.com/mmarkdown/mmark Mmark Markdown Processor - mmark.miek.nl" -->
+<rfc version="3" ipr="trust200902" docName="draft-sury-dnsop-deprecate-obsolete-resource-records-02" submissionType="IETF" category="std" xml:lang="en" xmlns:xi="http://www.w3.org/2001/XInclude" updates="1034, 1035, 3597, 4034" indexInclude="false" consensus="true">
 
-<!DOCTYPE rfc SYSTEM "rfc2629.dtd" [
-<!ENTITY RFC2119 SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.2119.xml">
-<!ENTITY RFC1035 PUBLIC "" "http://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.1035.xml">
-<!ENTITY RFC3597 PUBLIC "" "http://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.3597.xml">
-<!ENTITY RFC4034 PUBLIC "" "http://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.4034.xml">
-]>
+<front>
+<title abbrev="Deprecating RRTYPEs">Deprecating Obsolete DNS Resource Record Types</title><seriesInfo value="draft-sury-dnsop-deprecate-obsolete-resource-records-02" status="standard" name="Internet-Draft"></seriesInfo>
+<author initials="O." surname="Sury" fullname="Ondřej Surý"><organization>ISC</organization><address><postal><street>53 Main St.</street>
+<city>Newmarket</city>
+<code>03824</code>
+<country>USA</country>
+<region>NH</region>
+</postal><email>ondrej@isc.org</email>
+</address></author><author initials="E." surname="Hunt" fullname="Evan Hunt"><organization>ISC</organization><address><postal><street>53 Main St.</street>
+<city>Newmarket</city>
+<code>03824</code>
+<country>USA</country>
+<region>NH</region>
+</postal><email>each@isc.org</email>
+</address></author><date year="2021" month="April" day="14"></date>
+<area>Operations and Management</area>
+<workgroup>DNS Operations</workgroup>
+<keyword>DNS</keyword>
+<keyword>RRTYPE</keyword>
+<keyword>RR</keyword>
 
-<?rfc toc="yes"?>
-<?rfc strict="yes" ?>
-<?rfc linkmailto="yes" ?>
-<?rfc symrefs="yes"?>
-<?rfc compact="yes" ?>
-<?rfc subcompact="no" ?>
-<?rfc sortrefs="no" ?>
-<?rfc rfcedstyle="yes"?>
+<abstract>
+<t>This document deprecates Resource Record (RR) Types that are
+either no longer being used for anything meaningful or have
+been made obsolete by other RFCs.  This document updates
+<xref target="RFC1034"></xref>, <xref target="RFC1035"></xref>, <xref target="RFC3597"></xref>, and <xref target="RFC4034"></xref>.</t>
+</abstract>
 
-<rfc ipr="trust200902" docName="draft-sury-deprecate-obsolete-resource-records-00" category="std" updates="1035,3597,4035">
+</front>
+
+<middle>
+
+<section anchor="introduction"><name>Introduction</name>
+<t><xref target="RFC1035"></xref> and other documents have defined some
+Resource Record (RR) Types that are no longer in common use,
+some of which have been rendered obsolete by subsequent standards,
+but have never been clearly deprecated in the context of the DNS.
+In some cases there have been interoperability problems between
+DNS implementations that support these types and those that do
+not - for example, because of DNS name compression in the
+wire format. Continued support for these RR Types imposes a
+complexity cost on new implementations for little benefit.</t>
+<t>This document formally deprecates such RR Types, allowing
+implementations to drop specific support for them.</t>
+
+<section anchor="terminology"><name>Terminology</name>
+<t>The key words <bcp14>MUST</bcp14>, <bcp14>MUST NOT</bcp14>, <bcp14>REQUIRED</bcp14>, <bcp14>SHALL</bcp14>,
+<bcp14>SHALL NOT</bcp14>, <bcp14>SHOULD</bcp14>, <bcp14>SHOULD NOT</bcp14>, <bcp14>RECOMMENDED</bcp14>, <bcp14>MAY</bcp14>,
+and <bcp14>OPTIONAL</bcp14> in this document are to be interpreted as described in
+<xref target="RFC2119"></xref>.</t>
+</section>
+</section>
+
+<section anchor="deprecating-md-mf-mb-mg-mr-minfo-maila-and-mailb-rr-types"><name>Deprecating MD, MF, MB, MG, MR, MINFO, MAILA, and MAILB RR Types</name>
+<t>The MD, MF, MB, MG, MR, MINFO, MAILA, and MAILB RR Types aren't used in any
+existing standards, and this documents deprecates their usage.  The MD, MF,
+MB, MG, MR, and MINFO RR Types RDATA contain a domain name that could be
+compressed in the RDATA section.</t>
+<t>As an update to <xref target="RFC3597"></xref> and <xref target="RFC4034"></xref> this document specifies that
+for MD, MF, MB, MG, MR, and MINFO RR types, the canonical form is such that
+no downcasing of embedded domain names takes place, and is otherwise
+identical to the canonical form specified in <xref target="RFC4034" sectionFormat="bare" relative="#" section="6.2"></xref>.</t>
+</section>
+
+<section anchor="iana"><name>IANA Considerations</name>
+<t>This document updates the IANA registry &quot;Domain Name System (DNS)
+Parameters&quot; (<xref target="DNS-IANA"></xref>) as follows:</t>
+<table><name>Updates to DNS RR Types
+</name>
+<thead>
+<tr>
+<th>TYPE</th>
+<th>Value</th>
+<th>Meaning</th>
+<th>Reference</th>
+</tr>
+</thead>
+
+<tbody>
+<tr>
+<td>MD</td>
+<td>3</td>
+<td>DEPRECATED</td>
+<td>This document</td>
+</tr>
+
+<tr>
+<td>MF</td>
+<td>4</td>
+<td>DEPRECATED</td>
+<td>This document</td>
+</tr>
+
+<tr>
+<td>MB</td>
+<td>7</td>
+<td>DEPRECATED</td>
+<td>This document</td>
+</tr>
+
+<tr>
+<td>MG</td>
+<td>8</td>
+<td>DEPRECATED</td>
+<td>This document</td>
+</tr>
+
+<tr>
+<td>MR</td>
+<td>9</td>
+<td>DEPRECATED</td>
+<td>This document</td>
+</tr>
+
+<tr>
+<td>MINFO</td>
+<td>14</td>
+<td>DEPRECATED</td>
+<td>This document</td>
+</tr>
+</tbody>
+</table></section>
+
+<section anchor="implementation"><name>Implementation Considerations</name>
+<t>Obsolete types will be flagged as DEPRECATED in the IANA registry, and the
+following guidance is given to DNS implementors in the handling of these RR
+types:</t>
+
+<ol>
+<li><t>Authoritative DNS Servers SHOULD issue a warning when loading zones that
+contain DEPRECATED RR Types;</t>
+</li>
+<li><t>DNS Servers MUST NOT compress RDATA when rendering DEPRECATED RR Types
+to wire format;</t>
+</li>
+<li><t>Recursive DNS Servers MAY support legacy compression in DEPRECATED RR
+Types for received data for backward compatibility if desired, but
+SHOULD warn if such information is received.  Compressed RDATA in
+DEPRECATED RR Types MUST be uncompressed before sending and they MUST
+NOT be re-transmitted;</t>
+</li>
+<li><t>DNS Clients which receive DEPRECATED RR Types MAY interpret them as
+unknown RR types (<xref target="RFC3597"></xref>), and MUST NOT interfere with
+their transmission;</t>
+</li>
+<li><t>DNSSEC Validators and Signers SHOULD treat RDATA for DEPRECATED RR Types
+as opaque with respect to canonical RR ordering and deduplication;</t>
+</li>
+<li><t>DEPRECATED RR Types MUST NOT be treated as a known type with respect to
+the wire protocol.</t>
+</li>
+</ol>
+</section>
+
+<section anchor="security"><name>Security Considerations</name>
+<t>This document has no security considerations.</t>
+</section>
+
+<section anchor="operation"><name>Operational Considerations</name>
+<t>The varying states of implementation of MD, MF, MB, MG, MR, and MINFO RR
+Types have already caused operational problems between DNS implementations
+that do implement the aforementioned types and those that don't, because of
+mismatched handling of DNS compression on the wire.  This document aims to
+rectify the situation by encouraging removal of support for all these RR
+types in all DNS implementations.  This should not cause signficant
+operational problems because these records are not in wide use on the
+Internet. [COMMENT: Some data?]</t>
+</section>
+
+<section anchor="ack"><name>Acknowledgments</name>
+<t>The authors would like to thank Peter van Dijk for prompting us to write
+the draft, Daniel Salzman for reviewing the document, and Michael
+Casadevall for contributions to the Implementation Considerations section.</t>
+</section>
+
+</middle>
+
+<back>
+<references><name>Normative References</name>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.1034.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.1035.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.2119.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.3597.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.4034.xml"/>
+</references>
+<references><name>Informative References</name>
+<reference anchor="DNS-IANA" target="https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml">
   <front>
-    <title abbrev="Deprecating old mail RRTYPES">Deprecating obsolete DNS Resource Records Types</title>
-    <author fullname="Ondrej Sury" initials="O." surname="Sury">
-      <organization>Internet Systems Consortium</organization>
-      <address>
-	<postal>
-	  <street/>
-	  <country>CZ</country>
-	</postal>
-        <email>ondrej@isc.org</email>
-      </address>
+    <title>Domain Name System (DNS) Parameters</title>
+    <author>
+      <organization></organization>
     </author>
-    <date year="2018"/>
-    <area>Ops</area>
-    <workgroup>dnsop</workgroup>
-    <keyword>Internet-Draft</keyword>
-    <abstract>
-      <t>
-	This document deprecates Resource Records (RR) Types that are
-	either not being used for anything meaningful or were been
-	already made obsolete by other RFCs.  This document updates
-	<xref target="RFC1035"/>, <xref target="RFC1035"/>, <xref
-	target="RFC4034"/>.
-      </t>
-    </abstract>
+    <date></date>
   </front>
-  <!-- ====================================================================== -->
-  <middle>
+</reference>
+</references>
 
-    <section anchor="introduction" title="Introduction">
-      <t>
-	<xref target="RFC1035"/> and other documents have defined some
-	Resource Record (RR) Types that are no longer in common use,
-	some of which have been rendered obsolete by subsequent standards,
-	but have never been clearly deprecated in the context of the DNS.
-	In some cases there have been interoperability problems between
-	DNS implementations that support these types and those that do
-	not - for example, because of DNS name compression in the
-	wire format. Continued support for these RR Types imposes a
-	complexity cost on new implementations for little benefit.
-      </t>
-      <t>
-	This document formally deprecates such RR Types, allowing
-	implementations to drop specific support for them.
-      </t>
-    </section>
+</back>
 
-    <section title="Deprecating MD, MF, MB, MG, MR, MINFO, MAILA, and MAILBRR Types">
-      <t>
-	The MD, MF, MB, MG, MR, MINFO, MAILA, and MAILB RR Types
-	aren't used in any existing standards, and this documents
-	deprecates their usage.  The MD, MF, MB, MG, MR, and MINFO RR
-	Types RDATA contain a domain name that could be compressed in
-	the RDATA section.
-      </t>
-
-      <t>
-	As an update to <xref target="RFC3597"/> and <xref
-	target="RFC4034"/> this document specifies that for MD, MF,
-	MB, MG, MR, and MINFO RR types, the canonical form is such
-	that no downcasing of embedded domain names takes place, and
-	is otherwise identical to the canonical form specified in <xref
-	target="RFC4034"/> section 6.2.
-      </t>
-    </section>
-
-    <section anchor="iana" title="IANA Considerations">
-      <t>This documents updates the IANA registry "Domain Name System (DNS) Parameters" (<xref target="DNS-IANA"/>).</t>
-	
-      <texttable>
-        <ttcol>TYPE</ttcol>     <ttcol>Value</ttcol>      <ttcol>Meaning</ttcol>      <ttcol>Reference</ttcol>
-	<c>MD</c>               <c>3</c>                  <c>DEPRECATED</c> <c>This document</c>
-	<c>MF</c>               <c>4</c>                  <c>DEPRECATED</c> <c>This document</c>
-	<c>MB</c>               <c>7</c>                  <c>DEPRECATED</c> <c>This document</c>
-	<c>MG</c>               <c>8</c>                  <c>DEPRECATED</c> <c>This document</c>
-	<c>MR</c>               <c>9</c>                  <c>DEPRECATED</c> <c>This document</c>
-	<c>MINFO</c>            <c>14</c>                 <c>DEPRECATED</c> <c>This document</c>
-      </texttable>
-    </section>
-
-    <section anchor="implementation" title="Implementation Considerations">
-      <t>
-	  Types will be flagged as obsolete/deprecated in the IANA
-	  registry, and the following guidance is given to DNS
-	  implementors in the handling of obsolete/deprecated RR
-	  types:
-	  <list style="numbers">
-	    <t>
-	      Authoritative DNS Servers SHOULD issue a warning when
-	      loading zones that contain DEPRECATED RR Types;
-	    </t>
-
-	    <t>
-	      DNS Servers MUST NOT compress RDATA when rendering
-	      DEPRECATED RR Types to wire format;
-	    </t>
-
-	    <t>
-	      Recursive DNS Servers MAY support legacy compression in
-	      DEPRECATED RR Types for received data for backward
-	      compatibility if desired, but SHOULD warn if such
-	      information is received.  Compressed RDATA in DEPRECATED
-	      RR Types MUST be uncompressed before sending and they
-	      MUST NOT be re-transmitted;
-	    </t>
-	    
-	    <t>
-	      DNS Clients which receive DEPRECATED RR Types MAY
-	      interpret them as unknown RR types (<xref
-	      target="RFC3597"/>), and MUST NOT interfere with their
-	      transmission;
-	    </t>
-	    
-	    <t>
-	      DNSSEC Validators and Signers SHOULD treat RDATA for
-	      DEPRECATED RR Types as opaque with respect to canonical
-	      RR ordering and deduplication;
-	    </t>
-
-	    <t>
-	      DEPRECATED RR Types MUST never be treated as a
-	      known-type with respect to the wire protocol.
-	    </t>
-	  </list>
-      </t>
-    </section>
-    
-    <section anchor="security" title="Security Considerations">
-      <t>
-	This document has no security considerations.
-      </t>
-    </section>
-
-    <section anchor="operation" title="Operational Considerations">
-      <t>
-	The varying states of implementation of MD, MF, MB, MG,
-	MR, and MINFO RR Types has already caused operational problems
-	between DNS implementations that do implement the aforementioned
-	types and those that don't because of DNS compression on the wire.
-	This document aims to rectify the situation by encouraging removal
-	of support for all these RR types in DNS implementations.  This
-	should not cause signficant operational problems because these
-	records are not in wide use on the Internet. [COMMENT: Some data?]
-      </t>
-    </section>
-
-    <section anchor="ack" title="Acknowledgements">
-      <t>
-	Peter van Dijk for poking me to write the draft.  Daniel
-	Salzman for reviewing the document.  Evan Hunt and Michael
-	Casadevall to write Implementation Considerations section.
-      </t>
-    </section>
-
-  </middle>
-  <!-- ====================================================================== -->
-  <back>
-    <references title="Normative References">
-      &RFC1035;
-      &RFC3597;
-      &RFC4034;
-    </references>
-    <references title="Informative References">
-      <reference anchor="DNS-IANA" target="https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml">
-        <front>
-          <title>Domain Name System (DNS) Parameters</title>
-          <author initials="" surname="" fullname="">
-            <organization />
-          </author>
-          <date />
-        </front>
-      </reference>
-    </references>
-    <!-- ====================================================================== -->
-  </back>
 </rfc>

--- a/draft-sury-dnsop-deprecate-obsolete-resource-records.xml
+++ b/draft-sury-dnsop-deprecate-obsolete-resource-records.xml
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- name="GENERATOR" content="github.com/mmarkdown/mmark Mmark Markdown Processor - mmark.miek.nl" -->
-<rfc version="3" ipr="trust200902" docName="draft-sury-dnsop-deprecate-obsolete-resource-records-02" submissionType="IETF" category="std" xml:lang="en" xmlns:xi="http://www.w3.org/2001/XInclude" updates="1034, 1035, 3597, 4034" indexInclude="false" consensus="true">
+<rfc version="3" ipr="trust200902" docName="draft-sury-dnsop-deprecate-obsolete-resource-records-02" submissionType="IETF" category="std" xml:lang="en" xmlns:xi="http://www.w3.org/2001/XInclude" updates="1034, 1035, 3597, 4034" indexInclude="true" consensus="true">
 
 <front>
 <title abbrev="Deprecating RRTYPEs">Deprecating Obsolete DNS Resource Record Types</title><seriesInfo value="draft-sury-dnsop-deprecate-obsolete-resource-records-02" status="standard" name="Internet-Draft"></seriesInfo>
-<author initials="O." surname="Sury" fullname="Ondřej Surý"><organization>ISC</organization><address><postal><street>53 Main St.</street>
+<author initials="O." surname="Sury" fullname="Ondřej Surý"><organization>ISC</organization><address><postal><street>PO Box 360</street>
 <city>Newmarket</city>
-<code>03824</code>
+<code>03857</code>
 <country>USA</country>
 <region>NH</region>
 </postal><email>ondrej@isc.org</email>
-</address></author><author initials="E." surname="Hunt" fullname="Evan Hunt"><organization>ISC</organization><address><postal><street>53 Main St.</street>
+</address></author><author initials="E." surname="Hunt" fullname="Evan Hunt"><organization>ISC</organization><address><postal><street>PO Box 360</street>
 <city>Newmarket</city>
-<code>03824</code>
+<code>03857</code>
 <country>USA</country>
 <region>NH</region>
 </postal><email>each@isc.org</email>
-</address></author><date year="2021" month="April" day="14"></date>
+</address></author><date year="2022" month="September" day="19"></date>
 <area>Operations and Management</area>
 <workgroup>DNS Operations</workgroup>
 <keyword>DNS</keyword>
@@ -25,9 +25,10 @@
 
 <abstract>
 <t>This document deprecates Resource Record (RR) Types that are
-either no longer being used for anything meaningful or have
-been made obsolete by other RFCs.  This document updates
-<xref target="RFC1034"></xref>, <xref target="RFC1035"></xref>, <xref target="RFC3597"></xref>, and <xref target="RFC4034"></xref>.</t>
+either no longer being used in any meaningful way the DNS, or
+have already been rendered obsolete by other RFCs.  This
+document updates <xref target="RFC1034"></xref>, <xref target="RFC1035"></xref>, <xref target="RFC3597"></xref>, and
+<xref target="RFC4034"></xref>.</t>
 </abstract>
 
 </front>
@@ -36,14 +37,13 @@ been made obsolete by other RFCs.  This document updates
 
 <section anchor="introduction"><name>Introduction</name>
 <t><xref target="RFC1035"></xref> and other documents have defined some
-Resource Record (RR) Types that are no longer in common use,
-some of which have been rendered obsolete by subsequent standards,
-but have never been clearly deprecated in the context of the DNS.
-In some cases there have been interoperability problems between
-DNS implementations that support these types and those that do
-not - for example, because of DNS name compression in the
-wire format. Continued support for these RR Types imposes a
-complexity cost on new implementations for little benefit.</t>
+Resource Record (RR) Types that are no longer in common use.
+Some of these have been rendered obsolete by subsequent standards,
+but were never clearly deprecated.  In some cases there have been
+interoperability problems between DNS implementations that supported
+these types and those that did not: for example, because of DNS name
+compression in the wire format. Continued support for these RR Types
+imposes a complexity cost on new implementations for little benefit.</t>
 <t>This document formally deprecates such RR Types, allowing
 implementations to drop specific support for them.</t>
 
@@ -56,14 +56,15 @@ and <bcp14>OPTIONAL</bcp14> in this document are to be interpreted as described 
 </section>
 
 <section anchor="deprecating-md-mf-mb-mg-mr-minfo-maila-and-mailb-rr-types"><name>Deprecating MD, MF, MB, MG, MR, MINFO, MAILA, and MAILB RR Types</name>
-<t>The MD, MF, MB, MG, MR, MINFO, MAILA, and MAILB RR Types aren't used in any
-existing standards, and this documents deprecates their usage.  The MD, MF,
-MB, MG, MR, and MINFO RR Types RDATA contain a domain name that could be
-compressed in the RDATA section.</t>
+<t>The MD, MF, MB, MG, MR, MINFO, MAILA, and MAILB RR Types are not used in
+any existing standards.  This document deprecates their usage.</t>
+<t>The MD, MF, MB, MG, MR, and MINFO RR Types contain domain names in their
+RDATA. DNS compression MUST NOT be applied to these domain names when
+sending.</t>
 <t>As an update to <xref target="RFC3597"></xref> and <xref target="RFC4034"></xref> this document specifies that
-for MD, MF, MB, MG, MR, and MINFO RR types, the canonical form is such that
-no downcasing of embedded domain names takes place, and is otherwise
-identical to the canonical form specified in <xref target="RFC4034" sectionFormat="bare" relative="#" section="6.2"></xref>.</t>
+for MD, MF, MB, MG, MR, and MINFO RR types, the canonical form such that
+they do NOT include downcasing of embedded domain names.  Canonical forms
+otherwise remain as specified in <xref target="RFC4034" sectionFormat="of" relative="#" section="6.2"></xref>.</t>
 </section>
 
 <section anchor="iana"><name>IANA Considerations</name>
@@ -122,6 +123,20 @@ Parameters&quot; (<xref target="DNS-IANA"></xref>) as follows:</t>
 <td>DEPRECATED</td>
 <td>This document</td>
 </tr>
+
+<tr>
+<td>MAILB</td>
+<td>253</td>
+<td>DEPRECATED</td>
+<td>This document</td>
+</tr>
+
+<tr>
+<td>MAILA</td>
+<td>254</td>
+<td>DEPRECATED</td>
+<td>This document</td>
+</tr>
 </tbody>
 </table></section>
 
@@ -140,18 +155,15 @@ to wire format;</t>
 <li><t>Recursive DNS Servers MAY support legacy compression in DEPRECATED RR
 Types for received data for backward compatibility if desired, but
 SHOULD warn if such information is received.  Compressed RDATA in
-DEPRECATED RR Types MUST be uncompressed before sending and they MUST
-NOT be re-transmitted;</t>
+DEPRECATED RR Types MUST be uncompressed before sending, and MUST
+NOT be re-transmitted in compressed form;</t>
 </li>
 <li><t>DNS Clients which receive DEPRECATED RR Types MAY interpret them as
-unknown RR types (<xref target="RFC3597"></xref>), and MUST NOT interfere with
+unknown RR Types (<xref target="RFC3597"></xref>), and MUST NOT interfere with
 their transmission;</t>
 </li>
 <li><t>DNSSEC Validators and Signers SHOULD treat RDATA for DEPRECATED RR Types
 as opaque with respect to canonical RR ordering and deduplication;</t>
-</li>
-<li><t>DEPRECATED RR Types MUST NOT be treated as a known type with respect to
-the wire protocol.</t>
 </li>
 </ol>
 </section>
@@ -161,19 +173,18 @@ the wire protocol.</t>
 </section>
 
 <section anchor="operation"><name>Operational Considerations</name>
-<t>The varying states of implementation of MD, MF, MB, MG, MR, and MINFO RR
+<t>Varying states of implementation of MD, MF, MB, MG, MR, and MINFO RR
 Types have already caused operational problems between DNS implementations
-that do implement the aforementioned types and those that don't, because of
-mismatched handling of DNS compression on the wire.  This document aims to
-rectify the situation by encouraging removal of support for all these RR
-types in all DNS implementations.  This should not cause signficant
-operational problems because these records are not in wide use on the
-Internet. [COMMENT: Some data?]</t>
+that did, and did not, implement them, as a result of different behavior
+with resepect to DNS compression on the wire. This document aims to rectify
+the situation by encourating removal of support for all these RR Types in
+DNS implementations. This should cause few if any operational problems,
+because these types are not in common use on the internet.</t>
 </section>
 
 <section anchor="ack"><name>Acknowledgments</name>
 <t>The authors would like to thank Peter van Dijk for prompting us to write
-the draft, Daniel Salzman for reviewing the document, and Michael
+this draft, Daniel Salzman for reviewing the document, and Michael
 Casadevall for contributions to the Implementation Considerations section.</t>
 </section>
 


### PR DESCRIPTION
- convert to markdown format
- add Makefile to build xml/txt/html using mmark
- fixed a few grammar issues that had been overlooked before